### PR TITLE
Add DB init script and mocha tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 ## Setup
 
 1. Run `npm install`
-2. Start the app with `node server/index.js`
-3. The server listens on the port defined by the `PORT` environment variable
+2. Initialise the database with `npm run init-db`
+3. Start the app with `node server/index.js`
+4. The server listens on the port defined by the `PORT` environment variable
    (default `3000`). Visit `http://localhost:<PORT>` to use the UI.
-4. Optional environment variables:
+5. Optional environment variables:
    - `DB_FILE` - location of the SQLite database file
    - `CRON_SCHEDULE` - cron expression for automatic scraping
    - `SCRAPE_URL` - URL to fetch tender data from

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "server/index.js",
   "scripts": {
-    "start": "node server/index.js"
+    "start": "node server/index.js",
+    "init-db": "node server/init-db.js",
+    "test": "mocha"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -11,5 +13,11 @@
     "ejs": "^3.1.9",
     "node-fetch": "^2.6.7",
     "node-cron": "^3.0.2"
+  },
+  "devDependencies": {
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^15.2.0"
   }
 }

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -1,0 +1,31 @@
+const sqlite3 = require('sqlite3').verbose();
+const config = require('./config');
+const logger = require('./logger');
+
+// Simple utility script used to initialize the database. It creates the
+// `tenders` table if it does not exist and then closes the connection. This
+// is handy for deployment environments where the application may not run long
+// enough to trigger table creation automatically.
+const db = new sqlite3.Database(config.dbFile, err => {
+  if (err) {
+    logger.error('Failed to open database:', err);
+    process.exit(1);
+  }
+});
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS tenders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    link TEXT UNIQUE,
+    date TEXT,
+    description TEXT
+  )`, err => {
+    if (err) {
+      logger.error('Failed to create table:', err);
+    } else {
+      logger.info('Database initialised');
+    }
+    db.close();
+  });
+});

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai');
+
+// Use an in-memory database for tests so nothing is persisted on disk.
+process.env.DB_FILE = ':memory:';
+
+// Clear the module cache to ensure the DB_FILE env var is read.
+delete require.cache[require.resolve('../server/db')];
+const db = require('../server/db');
+
+describe('Database helpers', () => {
+  it('insertTender ignores duplicates', async () => {
+    const first = await db.insertTender('t1', 'link1', '2024-01-01', 'desc');
+    const second = await db.insertTender('t1', 'link1', '2024-01-01', 'desc');
+    expect(first).to.equal(1);
+    expect(second).to.equal(0);
+  });
+
+  it('getTenders retrieves rows ordered by date', async () => {
+    // Insert two tenders with different dates
+    await db.insertTender('t2', 'link2', '2024-02-01', 'd');
+    await db.insertTender('t3', 'link3', '2024-03-01', 'd');
+    const rows = await db.getTenders();
+    expect(rows).to.have.length(3);
+    // Ensure ordering by descending date
+    expect(rows[0].date).to.equal('2024-03-01');
+    expect(rows[1].date).to.equal('2024-02-01');
+  });
+});

--- a/test/mock.html
+++ b/test/mock.html
@@ -1,0 +1,12 @@
+<div class="search-result">
+  <h2>Contract 1</h2>
+  <a href="/c1"></a>
+  <span class="date">2024-04-01</span>
+  <p>Description 1</p>
+</div>
+<div class="search-result">
+  <h2>Contract 2</h2>
+  <a href="/c2"></a>
+  <span class="date">2024-05-01</span>
+  <p>Description 2</p>
+</div>

--- a/test/scrape.test.js
+++ b/test/scrape.test.js
@@ -1,0 +1,33 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+// Use a shared in-memory database between the db module used in the test and
+// the one injected into scrape.js.
+process.env.DB_FILE = ':memory:';
+delete require.cache[require.resolve('../server/db')];
+const db = require('../server/db');
+
+// Load the HTML used to mock the tender website response.
+const html = fs.readFileSync(path.join(__dirname, 'mock.html'), 'utf8');
+
+// Stub fetch so scrape.js receives predictable HTML without making a network call.
+const fetchStub = sinon.stub().resolves({ text: async () => html });
+
+// Proxyquire allows us to inject the stubbed fetch and the real db instance when
+// requiring the scraper module.
+const scrape = proxyquire('../server/scrape', {
+  'node-fetch': fetchStub,
+  './db': db
+});
+
+describe('scrape.run', () => {
+  it('parses tenders from HTML and stores them', async () => {
+    const count = await scrape.run();
+    expect(count).to.equal(2);
+    const rows = await db.getTenders();
+    expect(rows).to.have.length(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `init-db` script for creating the `tenders` table
- document the new setup step in the README
- configure package.json with test and init-db scripts
- add mocha/chai/sinon dev dependencies
- provide tests for db helpers and scraper using an in-memory sqlite DB

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc027085483289e6b0cb930be31de