### PR TITLE
Add real-time scrape progress feedback

### DIFF
--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -10,6 +10,8 @@
   <button id="scrapeBtn">Run Scraper Now</button>
   <!-- Area to show status messages while scraping -->
   <div id="status"></div>
+  <!-- Rolling feed of progress messages from the scraper -->
+  <ul id="feed"></ul>
   <table>
     <tr><th>Title</th><th>Date</th><th>Description</th><th>Link</th></tr>
     <% tenders.forEach(t => { %>
@@ -23,32 +25,41 @@
   </table>
   <!-- Asynchronous scraping logic -->
   <script>
-    // When the "Run Scraper Now" button is clicked, fire off a fetch to the
-    // /scrape endpoint. While the request is in flight we display a temporary
-    // "Scraping..." message. Once complete, show how many tenders were added
-    // then refresh the page so the table reflects any new data.
-    document.getElementById('scrapeBtn').addEventListener('click', async () => {
+    // When the "Run Scraper Now" button is clicked we open an EventSource
+    // connection to /scrape-stream. Progress events are pushed from the server
+    // so we can update the UI in real time.
+    document.getElementById('scrapeBtn').addEventListener('click', () => {
       const statusEl = document.getElementById('status');
+      const feedEl = document.getElementById('feed');
 
-      // Inform the user that work is in progress.
+      // Reset any previous messages.
+      feedEl.innerHTML = '';
       statusEl.textContent = 'Scraping...';
 
-      try {
-        // Call the backend endpoint which kicks off the scraper.
-        const res = await fetch('/scrape');
-        const data = await res.json();
+      const src = new EventSource('/scrape-stream');
 
-        // Show how many new tenders were stored before reloading.
-        statusEl.textContent = `Added ${data.added} new tenders.`;
+      // Handle each message from the server. Regular updates contain progress
+      // info while the final message includes `done: true`.
+      src.onmessage = e => {
+        const data = JSON.parse(e.data);
 
-        // Give the user a moment to read the message, then reload the page to
-        // display the latest results.
-        setTimeout(() => location.reload(), 1000);
-      } catch (err) {
-        // Network or server errors end up here. Display a generic failure
-        // message so the user knows something went wrong.
+        if (data.done) {
+          // Final event - show summary and reload the page after a short delay.
+          statusEl.textContent = `Added ${data.added} new tenders.`;
+          setTimeout(() => location.reload(), 1000);
+          src.close();
+        } else {
+          // Append the current progress message to the feed list.
+          const li = document.createElement('li');
+          li.textContent = `(${data.index}/${data.total}) ${data.title}`;
+          feedEl.appendChild(li);
+        }
+      };
+
+      src.onerror = () => {
         statusEl.textContent = 'Error running scraper.';
-      }
+        src.close();
+      };
     });
   </script>
 </body>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -10,3 +10,12 @@ th, td {
   padding: 0.5rem;
   border: 1px solid #ccc;
 }
+
+/* Scrollable area showing progress messages during scraping */
+#feed {
+  margin-top: 1rem;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  padding-left: 1rem;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,32 @@ app.get('/scrape', async (req, res) => {
   res.json({ added: newTenders });
 });
 
+// GET /scrape-stream - Same as /scrape but streams progress updates using
+// Server-Sent Events so the frontend can display real-time feedback.
+app.get('/scrape-stream', async (req, res) => {
+  logger.info('Manual SSE scrape triggered');
+
+  // Setup headers required for Server-Sent Events. `flushHeaders()` forces the
+  // headers to be sent immediately so the connection remains open while we
+  // stream data.
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive'
+  });
+  res.flushHeaders();
+
+  // Helper to send a data payload to the client as a single SSE message.
+  const send = data => res.write(`data: ${JSON.stringify(data)}\n\n`);
+
+  // Run the scraper and stream progress for each tender found.
+  const count = await scrape.run(progress => send(progress));
+
+  // Emit a final message indicating completion and close the connection.
+  send({ done: true, added: count });
+  res.end();
+});
+
 // Schedule automatic scraping based on the CRON_SCHEDULE environment
 // variable. By default this runs once per day at 06:00.
 cron.schedule(config.cronSchedule, async () => {

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -9,7 +9,15 @@ const logger = require('./logger');
  *
  * @returns {Promise<number>} number of new tenders inserted into the database
  */
-module.exports.run = async function () {
+/**
+ * Run the scraper and optionally report progress for each tender found.
+ *
+ * @param {function(object):void} [onProgress] - Optional callback invoked after
+ *   each tender is processed. Receives an object containing the title, 1-based
+ *   index and total number of tenders.
+ * @returns {Promise<number>} number of new tenders inserted into the database
+ */
+module.exports.run = async function (onProgress) {
   try {
     // Fetch the search page with a realistic User-Agent so the request looks
     // like it is coming from a normal browser.
@@ -27,16 +35,25 @@ module.exports.run = async function () {
     // Track how many tenders were inserted during this run.
     let count = 0;
 
+    // Grab all search result elements so we know the total number upfront.
+    const results = $('.search-result').toArray();
+    const total = results.length;
+
     // Iterate over each search result and insert it into the database. The
     // insertTender function resolves with the number of rows inserted so we can
     // keep track of how many new tenders were added.
-    for (const el of $('.search-result').toArray()) {
+    for (const [i, el] of results.entries()) {
       // Extract tender details from the DOM element.
       const title = $(el).find('h2').text().trim();
       const link =
         config.scrapeBase + $(el).find('a').attr('href');
       const date = $(el).find('.date').text().trim();
       const desc = $(el).find('p').text().trim();
+
+      // Notify listeners of progress so the UI can be updated in real time.
+      if (onProgress) {
+        onProgress({ title, index: i + 1, total });
+      }
 
       try {
         // Attempt to store the tender. `insertTender` resolves with 1 when a


### PR DESCRIPTION
## Summary
- extend scraper to accept progress callback
- stream progress to clients via Server-Sent Events
- display progress feed on dashboard
- style progress feed

## Testing
- `npx mocha` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mocha)*

------
https://chatgpt.com/codex/tasks/task_e_685fc7ad61208328a885b6770f9fd6a7