### PR TITLE
Improve scraping feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ This application scrapes new tenders from the UK government's Contracts Finder w
 ## Scheduled cron job
 
 The scraper runs automatically using `node-cron`. With the default schedule `0 6 * * *` the job executes once every day at 06:00. Adjust `CRON_SCHEDULE` to change the frequency. You can also trigger a manual scrape by visiting `/scrape` or clicking the button on the dashboard.
+
+## Real-time feedback
+
+When a scrape is triggered the dashboard streams progress updates. It reports
+the source being scraped, how many tenders were discovered and whether each one
+was added to the database or skipped as a duplicate. A final message summarises
+how many new tenders were stored.

--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -54,7 +54,19 @@
       src.onmessage = e => {
         const data = JSON.parse(e.data);
 
-        if (data.done) {
+        if (data.start) {
+          // Initial event tells us which source is being scraped.
+          statusEl.textContent = `Scraping from ${data.source}...`;
+        } else if (data.step === 'found') {
+          // The scraper has parsed the page and knows how many tenders exist.
+          statusEl.textContent = `Found ${data.count} tenders.`;
+        } else if (data.step === 'tender') {
+          // Update the rolling feed with each tender processed.
+          const li = document.createElement('li');
+          li.textContent = `(${data.index}/${data.total}) ${data.title} - ${
+            data.inserted ? 'added' : 'skipped'}`;
+          feedEl.appendChild(li);
+        } else if (data.done) {
           // Final event - show summary and reload the page after a short delay.
           if (data.added === 0) {
             statusEl.textContent = 'No new tenders found.';
@@ -63,11 +75,6 @@
           }
           setTimeout(() => location.reload(), 1000);
           src.close();
-        } else {
-          // Append the current progress message to the feed list.
-          const li = document.createElement('li');
-          li.textContent = `(${data.index}/${data.total}) ${data.title}`;
-          feedEl.appendChild(li);
         }
       };
 

--- a/server/index.js
+++ b/server/index.js
@@ -53,6 +53,9 @@ app.get('/scrape-stream', async (req, res) => {
 
   // Run the scraper and stream progress for each tender found. The selected
   // source is forwarded to the scraper so different sites can be targeted.
+  // Emit an initial event letting the client know which source will be used.
+  send({ start: true, source: source.label, url: source.url });
+
   const count = await scrape.run(progress => send(progress), source);
 
   // Emit a final message indicating completion and close the connection.


### PR DESCRIPTION
## Summary
- emit progress details from the scraper
- forward progress events to frontend and display them
- show which source is scraped and how many tenders were found
- document real-time feedback capability

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd49e9f883288ab24e5823f7c901