### PR TITLE
Add usage instructions to dashboard

### DIFF
--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -6,6 +6,17 @@
 </head>
 <body>
   <h1>New Tenders</h1>
+  <!-- Brief instructions help new users understand the workflow -->
+  <div id="instructions">
+    <ul>
+      <!-- Choose which configured site the scraper will run against -->
+      <li>Select a tender source from the dropdown below.</li>
+      <!-- Manual execution immediately runs the scraper for the chosen source -->
+      <li>Click <strong>Run Scraper Now</strong> to start a manual scrape.</li>
+      <!-- Additional sources can be added at any time via the form -->
+      <li>Use the <strong>Add Source</strong> form to register a new target.</li>
+    </ul>
+  </div>
   <!-- Source selector allows the user to choose which site to scrape -->
   <label for="sourceSelect">Source:</label>
   <select id="sourceSelect">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -28,3 +28,16 @@ th, td {
 #addSourceForm input {
   margin-right: 0.5rem;
 }
+
+/* Highlighted callout containing usage help */
+#instructions {
+  background: #f5f5f5;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+}
+
+#instructions ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- teach users how to run the scraper
- style new instructions box

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600c08154c8328be0a183fc5698b84