### PR TITLE
Add multi-source tender parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This application scrapes new tenders from the UK government's Contracts Finder w
 - `SCOTLAND_URL` and `SCOTLAND_BASE` - overrides for the predefined Public
   Contracts Scotland source.
 - `WALES_URL` and `WALES_BASE` - overrides for the predefined Sell2Wales source.
+- `UKRI_URL` and `UKRI_BASE` - overrides for the predefined UKRI opportunities source.
+- `EUSUPPLY_URL` and `EUSUPPLY_BASE` - overrides for the predefined EU Supply source.
 - `CRON_SCHEDULE` - cron expression controlling automatic scraping (defaults to `0 6 * * *`).
 
 ## Scheduled cron job

--- a/server/config.js
+++ b/server/config.js
@@ -12,7 +12,8 @@ const defaultSource = {
     'https://www.contractsfinder.service.gov.uk/Search',
   base:
     process.env.SCRAPE_BASE ||
-    'https://www.contractsfinder.service.gov.uk'
+    'https://www.contractsfinder.service.gov.uk',
+  parser: 'contractsFinder'
 };
 
 // Additional example source. This can be overridden via environment variables
@@ -20,7 +21,8 @@ const defaultSource = {
 const exampleSource = {
   label: 'Example Source',
   url: process.env.EXAMPLE_URL || 'https://example.com/search',
-  base: process.env.EXAMPLE_BASE || 'https://example.com'
+  base: process.env.EXAMPLE_BASE || 'https://example.com',
+  parser: 'contractsFinder'
 };
 
 // Additional predefined sources showcasing how multiple tender portals can be
@@ -33,7 +35,8 @@ const scotlandSource = {
     'https://www.publiccontractsscotland.gov.uk/Search/search_main.aspx',
   base:
     process.env.SCOTLAND_BASE ||
-    'https://www.publiccontractsscotland.gov.uk'
+    'https://www.publiccontractsscotland.gov.uk',
+  parser: 'contractsFinder'
 };
 
 const walesSource = {
@@ -41,7 +44,24 @@ const walesSource = {
   url:
     process.env.WALES_URL ||
     'https://www.sell2wales.gov.wales/Search/Search_Switch.aspx',
-  base: process.env.WALES_BASE || 'https://www.sell2wales.gov.wales'
+  base: process.env.WALES_BASE || 'https://www.sell2wales.gov.wales',
+  parser: 'sell2wales'
+};
+
+const ukriSource = {
+  label: 'UKRI Opportunities',
+  url: process.env.UKRI_URL || 'https://www.ukri.org/opportunity/',
+  base: process.env.UKRI_BASE || 'https://www.ukri.org',
+  parser: 'ukri'
+};
+
+const euSupplySource = {
+  label: 'EU Supply UK',
+  url:
+    process.env.EUSUPPLY_URL ||
+    'https://uk.eu-supply.com/ctm/supplier/publictenders?B=UK',
+  base: process.env.EUSUPPLY_BASE || 'https://uk.eu-supply.com',
+  parser: 'eusupply'
 };
 
 module.exports = {
@@ -60,7 +80,9 @@ module.exports = {
     default: defaultSource,
     example: exampleSource,
     scotland: scotlandSource,
-    wales: walesSource
+    wales: walesSource,
+    ukri: ukriSource,
+    eusupply: euSupplySource
   },
 
   // Legacy fields maintained for backwards compatibility. These map to the
@@ -71,3 +93,4 @@ module.exports = {
   // Cron expression determining when the scraper runs automatically
   cronSchedule: process.env.CRON_SCHEDULE || '0 6 * * *'
 };
+

--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -1,32 +1,106 @@
-// Minimal HTML parser used to extract tender information without external
-// dependencies. It relies on regular expressions which are sufficient for the
-// simple markup structure returned by Contracts Finder.
+// Minimal HTML parsers used to extract tender information without external
+// dependencies. Each function targets the structure of a different procurement
+// portal. The main `parseTenders` wrapper chooses the appropriate parser based
+// on the supplied site key.
 
 /**
- * Parse the search results HTML and return an array of tender objects.
- *
- * @param {string} html - Raw HTML from the search results page
- * @returns {Array<{title: string, link: string, date: string, desc: string}>}
+ * Parse Contracts Finder markup. This is the original parser used by the
+ * project and acts as the default.
  */
-exports.parseTenders = function parseTenders(html) {
+function parseContractsFinder(html) {
   const tenders = [];
-
-  // Match each result block. The `[^]*?` pattern matches any text, including new
-  // lines, in a non-greedy way so we capture one result at a time.
   const blockRe = /<div class="search-result">([^]*?)<\/div>/g;
   let blockMatch;
   while ((blockMatch = blockRe.exec(html))) {
     const block = blockMatch[1];
-
-    // Extract required fields using small, targeted regexes. The "?" after each
-    // group ensures we do not throw if a piece of data is missing.
     const title = /<h2>(.*?)<\/h2>/.exec(block)?.[1].trim() || '';
     const link = /<a[^>]*href="([^"]+)"/.exec(block)?.[1] || '';
     const date = /<span class="date">(.*?)<\/span>/.exec(block)?.[1].trim() || '';
     const desc = /<p>(.*?)<\/p>/.exec(block)?.[1].trim() || '';
-
     tenders.push({ title, link, date, desc });
   }
-
   return tenders;
+}
+
+/**
+ * Rough parser for Sell2Wales listings. The site uses table rows for each
+ * opportunity so we scan for <tr> elements and extract link/text from the first
+ * anchor tag.
+ */
+function parseSell2Wales(html) {
+  const tenders = [];
+  const rowRe = /<tr[^>]*>([^]*?)<\/tr>/g;
+  let row;
+  while ((row = rowRe.exec(html))) {
+    const block = row[1];
+    const link = /<a[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/.exec(block);
+    if (!link) continue;
+    const title = link[2].trim();
+    const href = link[1];
+    const date = /(\d{2}\/\d{2}\/\d{4}|\d{4}-\d{2}-\d{2})/.exec(block)?.[1] || '';
+    const desc = /<p[^>]*>(.*?)<\/p>/.exec(block)?.[1].trim() || '';
+    tenders.push({ title, link: href, date, desc });
+  }
+  return tenders;
+}
+
+/**
+ * Parser for UKRI opportunities. Opportunities are usually wrapped in <article>
+ * elements with a heading link, description paragraph and optional <time> tag.
+ */
+function parseUkri(html) {
+  const tenders = [];
+  const artRe = /<article[^>]*>([^]*?)<\/article>/g;
+  let art;
+  while ((art = artRe.exec(html))) {
+    const block = art[1];
+    const link = /<a[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/.exec(block);
+    if (!link) continue;
+    const title = link[2].trim();
+    const href = link[1];
+    const date = /<time[^>]*>(.*?)<\/time>/.exec(block)?.[1].trim() || '';
+    const desc = /<p[^>]*>(.*?)<\/p>/.exec(block)?.[1].trim() || '';
+    tenders.push({ title, link: href, date, desc });
+  }
+  return tenders;
+}
+
+/**
+ * Parser for EU-Supply public tender tables. Each row represents a tender and
+ * usually contains a link along with date and description cells.
+ */
+function parseEuSupply(html) {
+  const tenders = [];
+  const rowRe = /<tr[^>]*>([^]*?)<\/tr>/g;
+  let row;
+  while ((row = rowRe.exec(html))) {
+    const block = row[1];
+    const link = /<a[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/.exec(block);
+    if (!link) continue;
+    const title = link[2].trim();
+    const href = link[1];
+    const date = /(\d{2}\/\d{2}\/\d{4}|\d{4}-\d{2}-\d{2})/.exec(block)?.[1] || '';
+    const desc = /<td[^>]*class="description"[^>]*>(.*?)<\/td>/.exec(block)?.[1].trim() || '';
+    tenders.push({ title, link: href, date, desc });
+  }
+  return tenders;
+}
+
+/**
+ * Select the appropriate parser for a site. Unknown keys fall back to the
+ * Contracts Finder parser since its format is the basis for our tests.
+ */
+exports.parseTenders = function parseTenders(html, site = 'contractsFinder') {
+  switch (site) {
+    case 'sell2wales':
+      return parseSell2Wales(html);
+    case 'ukri':
+      return parseUkri(html);
+    case 'eusupply':
+      return parseEuSupply(html);
+    case 'contractsFinder':
+    default:
+      return parseContractsFinder(html);
+  }
 };
+

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -21,9 +21,15 @@ const logger = require('./logger');
  */
 module.exports.run = async function (onProgress, source) {
   try {
-    // Determine the URL/base for this run. If a source is provided use it,
-    // otherwise fall back to the defaults defined in config.js.
-    const src = source || { url: config.scrapeUrl, base: config.scrapeBase };
+    // Determine the URL/base for this run. When no source is supplied we
+    // construct an object using the default Contracts Finder settings and the
+    // parser key expected by htmlParser.
+    const src =
+      source || {
+        url: config.scrapeUrl,
+        base: config.scrapeBase,
+        parser: 'contractsFinder'
+      };
 
     // Let the caller know which URL is being scraped. This is useful feedback
     // for both the UI and logs.
@@ -43,7 +49,8 @@ module.exports.run = async function (onProgress, source) {
     // Grab the raw HTML then extract tender information using our small
     // regex-based parser. This avoids the need for external HTML libraries.
     const html = await res.text();
-    const tenders = parseTenders(html);
+    // Forward the parser key so htmlParser knows which scraping strategy to use.
+    const tenders = parseTenders(html, src.parser);
 
     // Notify listeners how many tenders were discovered on the page.
     if (onProgress) {


### PR DESCRIPTION
## Summary
- add parser functions for Sell2Wales, UKRI and EU-Supply
- extend configuration with new sources and parser keys
- route scraper to the correct parser for each source
- document new environment variables

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686108684fc88328b71e8b550d06dbfd