### PR TITLE
Track last scrape time with stats view

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ the source being scraped, how many tenders were discovered and whether each one
 was added to the database or skipped as a duplicate. A final message summarises
 how many new tenders were stored.
 
+## Statistics
+
+The `/stats` page displays when the scraper last completed successfully. This
+helps you confirm that automated cron jobs are running as expected.
+
 ## Adding new sources
 
 The dashboard includes a small form for defining additional tender sources at

--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -6,7 +6,9 @@
 </head>
 <body>
   <h1>New Tenders</h1>
-  <a href="/admin">Admin</a>
+  <a href="/admin">Admin</a> |
+  <!-- Link to the statistics page showing when the scraper last ran -->
+  <a href="/stats">Stats</a>
   <!-- Brief instructions help new users understand the workflow -->
   <div id="instructions">
     <ul>

--- a/frontend/stats.ejs
+++ b/frontend/stats.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Scrape Stats</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Scrape Statistics</h1>
+  <a href="/">Back to dashboard</a>
+  <p>
+    <!-- Display the stored timestamp or a placeholder when no scrape has been run yet -->
+    Last scraped: <%= lastScraped ? lastScraped : 'Never' %>
+  </p>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,13 @@ app.get('/', async (req, res) => {
   res.render('index', { tenders, sources: config.sources });
 });
 
+// GET /stats - Simple page showing the timestamp of the last successful scrape
+// so users know how fresh the displayed data is.
+app.get('/stats', async (req, res) => {
+  const lastScraped = await db.getLastScraped();
+  res.render('stats', { lastScraped });
+});
+
 // POST /sources - Add a new scraping source at runtime. The request should
 // include a unique key along with label, url and base properties. Sources are
 // stored in memory so they persist only for the lifetime of the process.

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -15,7 +15,8 @@ const db = new sqlite3.Database(config.dbFile, err => {
   }
 });
 
-// Create the tenders table and close the connection once finished.
+// Create required tables and close the connection once finished. Both tables are
+// kept minimal so initialisation is fast even on constrained platforms.
 db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS tenders (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -23,6 +24,10 @@ db.serialize(() => {
     link TEXT UNIQUE,
     date TEXT,
     description TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT
   )`, err => {
     if (err) {
       logger.error('Failed to create table:', err);

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -98,6 +98,14 @@ module.exports.run = async function (onProgress, source) {
       }
     }
 
+    // Record when this scrape completed successfully so the UI can show
+    // freshnes information. Failures in this step should not abort the run.
+    try {
+      await db.setLastScraped(new Date().toISOString());
+    } catch (err) {
+      logger.error('Failed to update last_scraped timestamp:', err);
+    }
+
     // Return the number of newly inserted tenders.
     return count;
   } catch (err) {

--- a/test/scrape.test.js
+++ b/test/scrape.test.js
@@ -29,5 +29,7 @@ describe('scrape.run', () => {
     expect(count).to.equal(2);
     const rows = await db.getTenders();
     expect(rows).to.have.length(2);
+    const ts = await db.getLastScraped();
+    expect(ts).to.be.a('string');
   });
 });


### PR DESCRIPTION
## Summary
- store last scrape timestamp in new `metadata` table
- expose helper methods in `db.js`
- record timestamp in `scrape.run`
- add `/stats` route and view to display when the scraper last ran
- link new stats page from dashboard
- document stats page in README
- update tests for timestamp support

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611244baa08328bab9332affd9572b