### PR TITLE
Add source and scrape time columns to tender table

### DIFF
--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -45,12 +45,14 @@
   <!-- Rolling feed of progress messages from the scraper -->
   <ul id="feed"></ul>
   <table>
-    <tr><th>Title</th><th>Date</th><th>Description</th><th>Link</th></tr>
+    <tr><th>Title</th><th>Date</th><th>Description</th><th>Source</th><th>Scraped At</th><th>Link</th></tr>
     <% tenders.forEach(t => { %>
       <tr>
         <td><%= t.title %></td>
         <td><%= t.date %></td>
         <td><%= t.description %></td>
+        <td><%= t.source %></td>
+        <td><%= t.scraped_at %></td>
         <td><a href="<%= t.link %>">View</a></td>
       </tr>
     <% }) %>

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -23,7 +23,9 @@ db.serialize(() => {
     title TEXT,
     link TEXT UNIQUE,
     date TEXT,
-    description TEXT
+    description TEXT,
+    source TEXT,
+    scraped_at TEXT
   )`);
   db.run(`CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -71,12 +71,16 @@ module.exports.run = async function (onProgress, source) {
       const link = src.base + tender.link;
       const date = tender.date;
       const desc = tender.desc;
+      // Include metadata about where and when the tender was scraped so
+      // the dashboard can display this context to the user.
+      const srcLabel = src.label;
+      const scrapedAt = new Date().toISOString();
 
       let inserted = 0;
       try {
         // Attempt to store the tender. `insertTender` resolves with 1 when a
         // new record was inserted or 0 if the tender already existed.
-        inserted = await db.insertTender(title, link, date, desc);
+        inserted = await db.insertTender(title, link, date, desc, srcLabel, scrapedAt);
 
         if (inserted) {
           count += 1;

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -9,20 +9,37 @@ const db = require('../server/db');
 
 describe('Database helpers', () => {
   it('insertTender ignores duplicates', async () => {
-    const first = await db.insertTender('t1', 'link1', '2024-01-01', 'desc');
-    const second = await db.insertTender('t1', 'link1', '2024-01-01', 'desc');
+    const first = await db.insertTender(
+      't1',
+      'link1',
+      '2024-01-01',
+      'desc',
+      'source',
+      '2024-01-02T00:00:00Z'
+    );
+    const second = await db.insertTender(
+      't1',
+      'link1',
+      '2024-01-01',
+      'desc',
+      'source',
+      '2024-01-02T00:00:00Z'
+    );
     expect(first).to.equal(1);
     expect(second).to.equal(0);
   });
 
   it('getTenders retrieves rows ordered by date', async () => {
     // Insert two tenders with different dates
-    await db.insertTender('t2', 'link2', '2024-02-01', 'd');
-    await db.insertTender('t3', 'link3', '2024-03-01', 'd');
+    await db.insertTender('t2', 'link2', '2024-02-01', 'd', 's', '2024-02-02T00:00:00Z');
+    await db.insertTender('t3', 'link3', '2024-03-01', 'd', 's', '2024-03-02T00:00:00Z');
     const rows = await db.getTenders();
     expect(rows).to.have.length(3);
     // Ensure ordering by descending date
     expect(rows[0].date).to.equal('2024-03-01');
     expect(rows[1].date).to.equal('2024-02-01');
+    // New columns should be populated
+    expect(rows[0].source).to.be.a('string');
+    expect(rows[0].scraped_at).to.be.a('string');
   });
 });

--- a/test/scrape.test.js
+++ b/test/scrape.test.js
@@ -29,6 +29,8 @@ describe('scrape.run', () => {
     expect(count).to.equal(2);
     const rows = await db.getTenders();
     expect(rows).to.have.length(2);
+    expect(rows[0]).to.have.property('source');
+    expect(rows[0]).to.have.property('scraped_at');
     const ts = await db.getLastScraped();
     expect(ts).to.be.a('string');
   });


### PR DESCRIPTION
## Summary
- extend DB schema with `source` and `scraped_at`
- pass new metadata from scraper
- display new fields on dashboard
- update tests for new columns

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861162f8c4883288e370054399e0e97