### PR TITLE
Implement session-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This application scrapes new tenders from the UK government's Contracts Finder w
   results table.
 - **Add a source** using the *Add Source* form. Provide a key, label, search URL
   and base URL. The source is added immediately for the current session.
+- **Manage the application** by registering at `/register`, logging in at
+  `/login` and visiting `/admin`. Only authenticated users can access admin
+  functions.
 - **Automatic scraping** runs in the background according to the `CRON_SCHEDULE`
   environment variable (default `0 6 * * *`). Results are stored in the
   database without any manual interaction.

--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -6,7 +6,8 @@
 </head>
 <body>
   <h1>Admin</h1>
-  <a href="/">Back to dashboard</a>
+  <a href="/">Back to dashboard</a> |
+  <a href="/logout">Logout</a>
 
   <!-- Form to trigger a full database reset -->
   <h2>Database</h2>

--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -6,7 +6,12 @@
 </head>
 <body>
   <h1>New Tenders</h1>
-  <a href="/admin">Admin</a> |
+  <% if (user) { %>
+    <a href="/admin">Admin</a> |
+    <a href="/logout">Logout</a> |
+  <% } else { %>
+    <a href="/login">Login</a> |
+  <% } %>
   <!-- Link to the statistics page showing when the scraper last ran -->
   <a href="/stats">Stats</a>
   <!-- Brief instructions help new users understand the workflow -->

--- a/frontend/login.ejs
+++ b/frontend/login.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Login</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Login</h1>
+  <% if (typeof error !== 'undefined') { %>
+    <p style="color:red"><%= error %></p>
+  <% } %>
+  <form method="POST" action="/login">
+    <input name="username" placeholder="Username" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <p>or <a href="/register">Register</a></p>
+</body>
+</html>

--- a/frontend/register.ejs
+++ b/frontend/register.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Register</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Register</h1>
+  <% if (typeof error !== 'undefined') { %>
+    <p style="color:red"><%= error %></p>
+  <% } %>
+  <form method="POST" action="/register">
+    <input name="username" placeholder="Username" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <button type="submit">Register</button>
+  </form>
+  <p>Already have an account? <a href="/login">Login</a></p>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "sqlite3": "^5.1.2",
     "ejs": "^3.1.9",
     "node-fetch": "^2.6.7",
-    "node-cron": "^3.0.2"
+    "node-cron": "^3.0.2",
+    "express-session": "^1.17.3",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "chai": "^4.3.7",

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -30,6 +30,11 @@ db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
   )`, err => {
     if (err) {
       logger.error('Failed to create table:', err);


### PR DESCRIPTION
## Summary
- add users table and db helpers
- create login and registration pages
- implement authentication middleware with sessions
- restrict admin routes to authenticated users
- document auth flow in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611bdb13008328b770ba37697d5307