### PR TITLE
Add persistent cron scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This application scrapes new tenders from the UK government's Contracts Finder w
 
 ## Scheduled cron job
 
-The scraper runs automatically using `node-cron`. With the default schedule `0 6 * * *` the job executes once every day at 06:00. Adjust `CRON_SCHEDULE` to change the frequency. You can also trigger a manual scrape by visiting `/scrape` or clicking the button on the dashboard.
+The scraper runs automatically using `node-cron`. With the default schedule `0 6 * * *` the job executes once every day at 06:00. Adjust `CRON_SCHEDULE` to change the frequency. You can also trigger a manual scrape by visiting `/scrape` or clicking the button on the dashboard. Any changes made via the admin interface are saved in the database so the chosen schedule is retained across restarts.
 
 ## Real-time feedback
 

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -42,4 +42,14 @@ describe('Database helpers', () => {
     expect(rows[0].source).to.be.a('string');
     expect(rows[0].scraped_at).to.be.a('string');
   });
+
+  it('cron schedule can be stored and retrieved', async () => {
+    // Initially no schedule should exist
+    const none = await db.getCronSchedule();
+    expect(none).to.equal(null);
+    // Persist a schedule and fetch it back
+    await db.setCronSchedule('*/5 * * * *');
+    const stored = await db.getCronSchedule();
+    expect(stored).to.equal('*/5 * * * *');
+  });
 });


### PR DESCRIPTION
## Summary
- store cron expression in the `metadata` table
- load saved schedule when the server starts
- reschedule cron job when updated via `/admin/cron`
- document cron persistence
- test schedule persistence

## Testing
- `npm test` *(fails: `mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68611df5c1148328ba6fa88468256f7a