### PR TITLE
Add persistent sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ helps you confirm that automated cron jobs are running as expected.
 
 The dashboard includes a small form for defining additional tender sources at
 runtime. Provide a unique key, display label, search URL and base URL. Newly
-added sources appear in the drop-down menu immediately but are not persisted
-beyond the current process.
+added sources appear in the drop-down menu immediately and are also stored in
+the SQLite database so they are available after restarting the server.

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -35,6 +35,13 @@ db.serialize(() => {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT UNIQUE,
     password TEXT
+  );
+  db.run(`CREATE TABLE IF NOT EXISTS sources (
+    key TEXT PRIMARY KEY,
+    label TEXT,
+    url TEXT,
+    base TEXT,
+    parser TEXT
   )`, err => {
     if (err) {
       logger.error('Failed to create table:', err);

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -52,4 +52,11 @@ describe('Database helpers', () => {
     const stored = await db.getCronSchedule();
     expect(stored).to.equal('*/5 * * * *');
   });
+
+  it('sources can be persisted and loaded', async () => {
+    await db.insertSource('x', 'Example', 'http://e', 'http://b', 'contractsFinder');
+    const rows = await db.getSources();
+    expect(rows).to.have.length(1);
+    expect(rows[0].key).to.equal('x');
+  });
 });


### PR DESCRIPTION
## Summary
- support saving custom sources in SQLite
- load saved sources on startup
- persist source when posted to `/sources`
- document persistence in README
- add database helper tests for source persistence

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861204a47d0832887b7641ebc92dd24