### PR TITLE
Add multi-source scrape feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Procurement Scraper GUI
 
-This application scrapes new tenders from the UK government's Contracts Finder website and the EU Supply portal (or other configurable sources) and displays them in a simple dashboard. Results are stored in a local SQLite database so you can browse them even after the scraper has finished running.
+This application scrapes new tenders from several procurement portals including the UK government's Contracts Finder website, the EU Supply portal and example sources like Sell2Wales and UKRI. Results are stored in a local SQLite database so you can browse them even after the scraper has finished running.
 
 ## Setup
 
@@ -25,6 +25,8 @@ This application scrapes new tenders from the UK government's Contracts Finder w
 - **Run the scraper** by selecting a source from the drop-down list and clicking
   **Scrape**. Progress messages stream to the page and new tenders appear in the
   results table.
+- **Scrape all sources** at once by visiting `/scrape-all`. Each source is
+  processed sequentially and the response details which succeeded or failed.
 - **Add a source** using the *Add Source* form. Provide a key, label, search URL
   and base URL. The source is added immediately for the current session.
 - **Manage the application** by registering at `/register`, logging in at
@@ -42,6 +44,8 @@ This application scrapes new tenders from the UK government's Contracts Finder w
 - `SCRAPE_URL` - URL used to fetch tender data.
 - `SCRAPE_BASE` - base URL prepended to scraped tender links.
 - `EUSUPPLY_URL` and `EUSUPPLY_BASE` - overrides for the built-in EU Supply source.
+- `SELL2WALES_URL` and `SELL2WALES_BASE` - overrides for the Sell2Wales source.
+- `UKRI_URL` and `UKRI_BASE` - overrides for the UKRI source.
 - `CRON_SCHEDULE` - cron expression controlling automatic scraping (defaults to `0 6 * * *`).
 
 ## Scheduled cron job
@@ -66,3 +70,5 @@ The dashboard includes a small form for defining additional tender sources at
 runtime. Provide a unique key, display label, search URL and base URL. Newly
 added sources appear in the drop-down menu immediately and are also stored in
 the SQLite database so they are available after restarting the server.
+The application ships with Contracts Finder, EU Supply, Sell2Wales and UKRI
+configured out of the box.

--- a/server/config.js
+++ b/server/config.js
@@ -17,8 +17,8 @@ const defaultSource = {
 };
 
 // Other sources previously included here have been removed as they either no
-// longer work or never provided reliable results. Only Contracts Finder and
-// EU Supply remain as built-in options.
+// longer work or never provided reliable results. A small selection is kept to
+// demonstrate multiple scraping strategies.
 
 const euSupplySource = {
   label: 'EU Supply UK',
@@ -27,6 +27,24 @@ const euSupplySource = {
     'https://uk.eu-supply.com/ctm/supplier/publictenders?B=UK',
   base: process.env.EUSUPPLY_BASE || 'https://uk.eu-supply.com',
   parser: 'eusupply'
+};
+
+// Example Sell2Wales source used by the additional `sell2wales` parser.
+const sell2walesSource = {
+  label: 'Sell2Wales',
+  url:
+    process.env.SELL2WALES_URL ||
+    'https://www.sell2wales.gov.wales/search?q=',
+  base: process.env.SELL2WALES_BASE || 'https://www.sell2wales.gov.wales',
+  parser: 'sell2wales'
+};
+
+// Example UKRI opportunities source.
+const ukriSource = {
+  label: 'UKRI',
+  url: process.env.UKRI_URL || 'https://www.ukri.org/opportunities',
+  base: process.env.UKRI_BASE || 'https://www.ukri.org',
+  parser: 'ukri'
 };
 
 module.exports = {
@@ -43,7 +61,9 @@ module.exports = {
   // added here or injected via environment variables.
   sources: {
     default: defaultSource,
-    eusupply: euSupplySource
+    eusupply: euSupplySource,
+    sell2wales: sell2walesSource,
+    ukri: ukriSource
   },
 
   // Legacy fields maintained for backwards compatibility. These map to the

--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -97,6 +97,12 @@ exports.parseTenders = function parseTenders(html, site = 'contractsFinder') {
     // EU Supply uses a different table structure so it has its own parser.
     case 'eusupply':
       return parseEuSupply(html);
+    // Sell2Wales and UKRI each use their own markup so custom parsers exist
+    // for them as well.
+    case 'sell2wales':
+      return parseSell2Wales(html);
+    case 'ukri':
+      return parseUkri(html);
     // Any unknown keys fall back to the Contracts Finder format which our
     // tests are based on.
     case 'contractsFinder':

--- a/server/index.js
+++ b/server/index.js
@@ -184,6 +184,13 @@ app.get('/scrape', async (req, res) => {
   res.json({ added: newTenders });
 });
 
+// GET /scrape-all - Run the scraper against every configured source.
+app.get('/scrape-all', async (req, res) => {
+  logger.info('Manual scrape triggered for all sources');
+  const results = await scrape.runAll();
+  res.json(results);
+});
+
 // GET /scrape-stream - Same as /scrape but streams progress updates using
 // Server-Sent Events so the frontend can display real-time feedback.
 app.get('/scrape-stream', async (req, res) => {

--- a/test/runAll.test.js
+++ b/test/runAll.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+// In-memory DB so nothing is persisted
+process.env.DB_FILE = ':memory:';
+delete require.cache[require.resolve('../server/db')];
+const db = require('../server/db');
+
+const html = fs.readFileSync(path.join(__dirname, 'mock.html'), 'utf8');
+const fetchStub = sinon.stub().resolves({ text: async () => html });
+
+const configStub = {
+  sources: {
+    a: { label: 'A', url: 'http://a', base: 'http://a', parser: 'contractsFinder' },
+    b: { label: 'B', url: 'http://b', base: 'http://b', parser: 'contractsFinder' }
+  },
+  scrapeUrl: '',
+  scrapeBase: ''
+};
+
+const scrape = proxyquire('../server/scrape', {
+  'node-fetch': fetchStub,
+  './db': db,
+  './config': configStub
+});
+
+describe('scrape.runAll', () => {
+  it('scrapes every configured source', async () => {
+    const results = await scrape.runAll();
+    expect(Object.keys(results)).to.have.length(2);
+    expect(results.a.added).to.equal(2);
+    expect(results.b.added).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary
- expand built‑in sources and document them
- allow scraping all sources in one request
- implement bulk scrape helper
- expose `/scrape-all` endpoint
- extend HTML parser with Sell2Wales and UKRI cases
- test new `runAll` helper

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612dd29d008328a49d505cd3d02964