### PR TITLE
Improve source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,11 @@ runtime. Follow these steps to register a new site:
 7. Click **Add Source** to save. The source is stored in the database and can be
    selected immediately.
 
+When filling in the form you will be asked for four pieces of information:
+- **Key** – a short unique identifier used internally (e.g. `eusupply`).
+- **Label** – human readable name shown in the dashboard (e.g. `EU Supply UK`).
+- **Search URL** – the RSS feed or results page to scrape (e.g. `https://uk.eu-supply.com/ctm/supplier/publictenders?B=UK`).
+- **Base URL** – the website root prepended to tender links (e.g. `https://uk.eu-supply.com`).
+
 The application ships with Contracts Finder, EU Supply and a selection of other
 procurement portals pre-configured so you can start scraping immediately.

--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -24,6 +24,19 @@
 
   <!-- Manage scraping sources -->
   <h2>Sources</h2>
+  <!-- Help text explaining what each Add Source field does. The EU Supply
+       values are shown as a concrete example that users can copy -->
+  <div id="sourceHelp">
+    <p>Fill out the form below to register a new tender source.</p>
+    <ul>
+      <li><strong>Key</strong> &ndash; short identifier, e.g. <code>eusupply</code></li>
+      <li><strong>Label</strong> &ndash; display name such as <code>EU Supply UK</code></li>
+      <li><strong>Search URL</strong> &ndash; feed or listing, for EU Supply
+        <code>https://uk.eu-supply.com/ctm/supplier/publictenders?B=UK</code></li>
+      <li><strong>Base URL</strong> &ndash; website root, e.g.
+        <code>https://uk.eu-supply.com</code></li>
+    </ul>
+  </div>
   <ul id="sourceList">
     <% Object.keys(sources).forEach(key => { %>
       <li><%= key %> - <%= sources[key].label %></li>


### PR DESCRIPTION
## Summary
- expand README with detailed explanation of add-source fields and EU Supply example
- show help text on the admin page about how to add a source

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4e401f0832891c3e8b0939fbf5d