### PR TITLE
Improve admin UI and network hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ This application scrapes new tenders from several procurement portals including 
    ```bash
    node server/index.js
    ```
-   The UI will be available at `http://localhost:<PORT>`.
+   The UI will be available at `http://<HOST>:<PORT>`.
 
 ## Usage
 
-- **Access the dashboard** by navigating to `http://localhost:<PORT>` once the
+- **Access the dashboard** by navigating to `http://<HOST>:<PORT>` once the
   server is running.
 - **Run the scraper** by selecting a source from the drop-down list and clicking
   **Scrape**. Progress messages stream to the page and new tenders appear in the
@@ -44,6 +44,7 @@ This application scrapes new tenders from several procurement portals including 
 ## Environment variables
 
 - `PORT` - port for the Express server (default `3000`).
+- `HOST` - interface the server listens on (default `0.0.0.0`).
 - `FRONTEND_DIR` - directory for templates and static files.
 - `DB_FILE` - path to the SQLite database file.
 - `SCRAPE_URL` - URL used to fetch tender data for the default Contracts Finder feed.
@@ -61,6 +62,7 @@ This application scrapes new tenders from several procurement portals including 
 ## Scheduled cron job
 
 The scraper runs automatically using `node-cron`. With the default schedule `0 6 * * *` the job executes once every day at 06:00. Adjust `CRON_SCHEDULE` to change the frequency. You can also trigger a manual scrape by visiting `/scrape` or clicking the button on the dashboard. Any changes made via the admin interface are saved in the database so the chosen schedule is retained across restarts.
+The admin page provides dropdown fields to help build the cron expression if you are unfamiliar with the syntax.
 
 ## Real-time feedback
 

--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -18,8 +18,23 @@
   <!-- Form allowing the cron schedule to be changed dynamically -->
   <h2>Cron Schedule</h2>
   <form id="cronForm">
-    <input id="cronInput" placeholder="* * * * *" value="<%= cron %>" required>
+    <label>Minute
+      <select id="cronMin"></select>
+    </label>
+    <label>Hour
+      <select id="cronHour"></select>
+    </label>
+    <label>Day
+      <select id="cronDom"></select>
+    </label>
+    <label>Month
+      <select id="cronMon"></select>
+    </label>
+    <label>Weekday
+      <select id="cronDow"></select>
+    </label>
     <button type="submit">Update Schedule</button>
+    <span id="cronPreview"></span>
   </form>
 
   <!-- Manage scraping sources -->
@@ -37,15 +52,26 @@
         <code>https://uk.eu-supply.com</code></li>
     </ul>
   </div>
-  <ul id="sourceList">
+  <table id="sourceTable">
+    <tr><th>Key</th><th>Label</th><th>URL</th><th>Base</th></tr>
     <% Object.keys(sources).forEach(key => { %>
-      <li data-key="<%= key %>">
-        <%= key %> - <%= sources[key].label %>
-        <button class="editBtn" type="button">Edit</button>
-        <button class="deleteBtn" type="button">Delete</button>
-      </li>
+      <tr class="sourceRow" data-key="<%= key %>">
+        <td><%= key %></td>
+        <td><%= sources[key].label %></td>
+        <td><%= sources[key].url %></td>
+        <td><%= sources[key].base %></td>
+      </tr>
+      <tr class="detailRow" data-key="<%= key %>" style="display:none">
+        <td colspan="4">
+          Last scraped: <%= sourceStats[key] ? sourceStats[key].last_scraped || 'Never' : 'Never' %><br>
+          Tenders last scrape: <%= sourceStats[key] ? sourceStats[key].last_added : 0 %><br>
+          Total tenders: <%= sourceStats[key] ? sourceStats[key].total : 0 %><br>
+          <button class="editBtn" type="button">Edit</button>
+          <button class="deleteBtn" type="button">Delete</button>
+        </td>
+      </tr>
     <% }) %>
-  </ul>
+  </table>
   <form id="addSourceForm">
     <input id="newKey" placeholder="Key" required>
     <input id="newLabel" placeholder="Label" required>
@@ -56,7 +82,45 @@
 
 <script>
 const sourceData = <%- JSON.stringify(sources) %>;
+const statsData = <%- JSON.stringify(sourceStats) %>;
 let editingKey = null;
+
+// Populate the cron schedule dropdowns with numeric options
+function fill(select, max) {
+  for (let i = 0; i <= max; i++) {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = i;
+    select.appendChild(opt);
+  }
+}
+fill(document.getElementById('cronMin'), 59);
+fill(document.getElementById('cronHour'), 23);
+fill(document.getElementById('cronDom'), 31);
+fill(document.getElementById('cronMon'), 12);
+fill(document.getElementById('cronDow'), 6);
+
+// Initialise selects based on the stored schedule
+const parts = '<%= cron %>'.split(' ');
+document.getElementById('cronMin').value = parts[0];
+document.getElementById('cronHour').value = parts[1];
+document.getElementById('cronDom').value = parts[2];
+document.getElementById('cronMon').value = parts[3];
+document.getElementById('cronDow').value = parts[4];
+
+const cronPreview = document.getElementById('cronPreview');
+function buildCron() {
+  const min = document.getElementById('cronMin').value;
+  const hour = document.getElementById('cronHour').value;
+  const dom = document.getElementById('cronDom').value;
+  const mon = document.getElementById('cronMon').value;
+  const dow = document.getElementById('cronDow').value;
+  const str = `${min} ${hour} ${dom} ${mon} ${dow}`;
+  cronPreview.textContent = str;
+  return str;
+}
+document.querySelectorAll('#cronForm select').forEach(sel => sel.addEventListener('change', buildCron));
+buildCron();
 
 // Add a new tender source and reload on success.
 document.getElementById('addSourceForm').addEventListener('submit', async e => {
@@ -84,9 +148,14 @@ document.getElementById('addSourceForm').addEventListener('submit', async e => {
 });
 
 // Hook up edit and delete buttons for each listed source
-document.querySelectorAll('#sourceList li').forEach(li => {
-  const key = li.dataset.key;
-  li.querySelector('.editBtn').addEventListener('click', () => {
+document.querySelectorAll('#sourceTable .sourceRow').forEach(row => {
+  const key = row.dataset.key;
+  row.addEventListener('click', () => {
+    const detail = document.querySelector(`.detailRow[data-key="${key}"]`);
+    detail.style.display = detail.style.display === 'none' ? '' : 'none';
+  });
+  const detail = document.querySelector(`.detailRow[data-key="${key}"]`);
+  detail.querySelector('.editBtn').addEventListener('click', () => {
     const s = sourceData[key];
     document.getElementById('newKey').value = key;
     document.getElementById('newKey').disabled = true;
@@ -96,7 +165,7 @@ document.querySelectorAll('#sourceList li').forEach(li => {
     document.getElementById('addBtn').textContent = 'Update Source';
     editingKey = key;
   });
-  li.querySelector('.deleteBtn').addEventListener('click', async () => {
+  detail.querySelector('.deleteBtn').addEventListener('click', async () => {
     if (!confirm(`Delete source ${key}?`)) return;
     const res = await fetch(`/sources/${encodeURIComponent(key)}`, { method: 'DELETE' });
     if (res.ok) {
@@ -108,9 +177,10 @@ document.querySelectorAll('#sourceList li').forEach(li => {
 });
 
 // Submit new cron schedule so the server can reschedule the scraper.
+// Build the cron expression from the dropdowns and submit it to the server.
 document.getElementById('cronForm').addEventListener('submit', async e => {
   e.preventDefault();
-  const schedule = document.getElementById('cronInput').value.trim();
+  const schedule = buildCron();
   const res = await fetch('/admin/cron', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -71,3 +71,8 @@ button:hover {
   margin: 0;
   padding-left: 1.25rem;
 }
+
+/* Hide detail rows initially and give them a subtle background */
+.detailRow {
+  background: #f5f5f5;
+}

--- a/server/config.js
+++ b/server/config.js
@@ -99,6 +99,10 @@ const intendSource = {
 module.exports = {
   // Port the Express server listens on
   port: process.env.PORT || 3000,
+  // Network interface to bind the HTTP server to. Using 0.0.0.0 allows access
+  // from other machines on the network. The hostname is logged purely for
+  // convenience.
+  host: process.env.HOST || '0.0.0.0',
 
   // Directory containing frontend templates and static assets
   frontendDir: process.env.FRONTEND_DIR || path.join(__dirname, '../frontend'),

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -42,6 +42,12 @@ db.serialize(() => {
     url TEXT,
     base TEXT,
     parser TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS source_stats (
+    key TEXT PRIMARY KEY,
+    last_scraped TEXT,
+    last_added INTEGER,
+    total INTEGER
   )`, err => {
     if (err) {
       logger.error('Failed to create table:', err);

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -75,4 +75,13 @@ describe('Database helpers', () => {
     const rows = await db.getSources();
     expect(rows.some(r => r.key === 'z')).to.equal(false);
   });
+
+  it('source stats accumulate totals', async () => {
+    await db.updateSourceStats('s', '2024-01-01T00:00:00Z', 3);
+    await db.updateSourceStats('s', '2024-01-02T00:00:00Z', 2);
+    const rows = await db.getSourceStats();
+    const s = rows.find(r => r.key === 's');
+    expect(s.total).to.equal(5);
+    expect(s.last_added).to.equal(2);
+  });
 });


### PR DESCRIPTION
## Summary
- allow configuring host for network access
- track per-source scraping stats and expose them in admin dashboard
- add dropdown cron schedule builder for easier configuration
- display sources in expandable table with editing controls
- create new DB table for source statistics
- update README and tests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626f369e888328a9932c78b7a829e6