### PR TITLE
Fix cron schedule field order

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This application scrapes new tenders from several procurement portals including 
 ## Scheduled cron job
 
 The scraper runs automatically using `node-cron`. With the default schedule `0 6 * * *` the job executes once every day at 06:00. Adjust `CRON_SCHEDULE` to change the frequency. You can also trigger a manual scrape by visiting `/scrape` or clicking the button on the dashboard. Any changes made via the admin interface are saved in the database so the chosen schedule is retained across restarts.
-The admin page provides dropdown fields to help build the cron expression if you are unfamiliar with the syntax.
+The admin page provides dropdown fields to help build the cron expression if you are unfamiliar with the syntax. The form lists the hour before the minute for readability, but the cron expression itself always uses the order _minute hour_.
 
 ## Real-time feedback
 

--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -18,11 +18,11 @@
   <!-- Form allowing the cron schedule to be changed dynamically -->
   <h2>Cron Schedule</h2>
   <form id="cronForm">
-    <label>Minute
-      <select id="cronMin"></select>
-    </label>
     <label>Hour
       <select id="cronHour"></select>
+    </label>
+    <label>Minute
+      <select id="cronMin"></select>
     </label>
     <label>Day
       <select id="cronDom"></select>
@@ -109,6 +109,9 @@ document.getElementById('cronMon').value = parts[3];
 document.getElementById('cronDow').value = parts[4];
 
 const cronPreview = document.getElementById('cronPreview');
+// Build a cron expression from the dropdowns.
+// Note: cron syntax uses the order minute then hour, even
+// though the form displays hour first for readability.
 function buildCron() {
   const min = document.getElementById('cronMin').value;
   const hour = document.getElementById('cronHour').value;


### PR DESCRIPTION
## Summary
- reorder cron hour/minute fields so the time entry is less confusing
- clarify cron syntax in README
- document cron expression build function

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f310dfb88328826c1570cb3db299