### PR TITLE
Add awarded contracts scraping

### DIFF
--- a/frontend/available.ejs
+++ b/frontend/available.ejs
@@ -5,13 +5,14 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-  <h1>New Tenders</h1>
+  <h1>Available Contracts</h1>
   <% if (user) { %>
     <a href="/admin">Admin</a> |
     <a href="/logout">Logout</a> |
   <% } else { %>
     <a href="/login">Login</a> |
   <% } %>
+  <a href="/awarded">Awarded Contracts</a> |
   <!-- Link to the statistics page showing when the scraper last ran -->
   <a href="/stats">Stats</a>
   <!-- Brief instructions help new users understand the workflow -->

--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Tender Dashboard</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Awarded Contracts</h1>
+  <% if (user) { %>
+    <a href="/admin">Admin</a> |
+    <a href="/logout">Logout</a> |
+  <% } else { %>
+    <a href="/login">Login</a> |
+  <% } %>
+  <a href="/">Available Contracts</a> |
+  <!-- Link to the statistics page showing when the scraper last ran -->
+  <a href="/stats">Stats</a>
+  <!-- Brief instructions help new users understand the workflow -->
+  <div id="instructions">
+    <ul>
+      <!-- Choose which configured site the scraper will run against -->
+      <li>Select a tender source from the dropdown below.</li>
+      <!-- Manual execution immediately runs the scraper for the chosen source -->
+      <li>Click <strong>Run Scraper Now</strong> to start a manual scrape.</li>
+      <!-- Additional sources can be added at any time via the form -->
+      <li>Use the <strong>Add Source</strong> form to register a new target.</li>
+    </ul>
+  </div>
+  <!-- Source selector allows the user to choose which site to scrape -->
+  <label for="sourceSelect">Source:</label>
+  <select id="sourceSelect">
+    <% Object.keys(sources).forEach(key => { %>
+      <option value="<%= key %>"><%= sources[key].label %></option>
+    <% }) %>
+  </select>
+
+  <!-- Form allowing the user to add a new tender source dynamically -->
+  <form id="addSourceForm">
+    <h3>Add Source</h3>
+    <input id="newKey" placeholder="Key" required>
+    <input id="newLabel" placeholder="Label" required>
+    <input id="newUrl" placeholder="Search URL" required>
+    <input id="newBase" placeholder="Base URL" required>
+    <button type="submit">Add</button>
+  </form>
+
+  <!-- Buttons for manual scraping -->
+  <button id="scrapeBtn">Run Scraper Now</button>
+  <!-- New button kicks off scraping for every configured source -->
+  <button id="scrapeAllBtn">Run Scraper For All Sources</button>
+  <!-- Area to show status messages while scraping -->
+  <div id="status"></div>
+  <!-- Rolling feed of progress messages from the scraper -->
+  <ul id="feed"></ul>
+  <table>
+    <tr><th>Title</th><th>Date</th><th>Description</th><th>Source</th><th>Scraped At</th><th>Tags</th><th>Link</th></tr>
+    <% tenders.forEach(t => { %>
+      <tr>
+        <td><%= t.title %></td>
+        <td><%= t.date %></td>
+        <td><%= t.description %></td>
+        <td><%= t.source %></td>
+        <td><%= t.scraped_at %></td>
+        <td><%= t.tags %></td>
+        <td><a href="<%= t.link %>">View</a></td>
+      </tr>
+    <% }) %>
+  </table>
+  <!-- Asynchronous scraping logic -->
+  <script>
+    // When the "Run Scraper Now" button is clicked we open an EventSource
+    // connection to /scrape-stream. Progress events are pushed from the server
+    // so we can update the UI in real time.
+  document.getElementById('scrapeBtn').addEventListener('click', () => {
+      const statusEl = document.getElementById('status');
+      const feedEl = document.getElementById('feed');
+
+      // Reset any previous messages.
+      feedEl.innerHTML = '';
+      statusEl.textContent = 'Scraping...';
+
+      // Include the selected source in the request so the server knows which
+      // site to scrape.
+      const source = document.getElementById('sourceSelect').value;
+      const src = new EventSource(`/scrape-awarded-stream?source=${encodeURIComponent(source)}`);
+
+      // Handle each message from the server. Regular updates contain progress
+      // info while the final message includes `done: true`.
+      src.onmessage = e => {
+        const data = JSON.parse(e.data);
+
+        if (data.start) {
+          // Initial event tells us which source is being scraped.
+          statusEl.textContent = `Scraping from ${data.source}...`;
+        } else if (data.step === 'found') {
+          // The scraper has parsed the page and knows how many awards exist.
+          statusEl.textContent = `Found ${data.count} awards.`;
+        } else if (data.step === 'tender') {
+          // Update the rolling feed with each tender processed.
+          const li = document.createElement('li');
+          li.textContent = `(${data.index}/${data.total}) ${data.title} - ${
+            data.inserted ? 'added' : 'skipped'}`;
+          feedEl.appendChild(li);
+        } else if (data.done) {
+          // Final event - display a summary but keep the log visible so the
+          // user can review it without the page refreshing.
+          if (data.added === 0) {
+            statusEl.textContent = 'No new awards found.';
+          } else {
+            statusEl.textContent = `Added ${data.added} new awards.`;
+          }
+          // Close the SSE connection; the page is left intact so the logs
+          // remain available.
+          src.close();
+        }
+      };
+
+    src.onerror = () => {
+      statusEl.textContent = 'Error running scraper.';
+      src.close();
+    };
+  });
+
+  // Trigger scraping across all configured sources. This sends a simple
+  // fetch request to the /scrape-all endpoint and displays a summary once
+  // complete.
+  document.getElementById('scrapeAllBtn').addEventListener('click', async () => {
+    const statusEl = document.getElementById('status');
+    const feedEl = document.getElementById('feed');
+
+    // Clear previous output and show a starting message
+    feedEl.innerHTML = '';
+    statusEl.textContent = 'Scraping all sources...';
+
+    try {
+      const res = await fetch('/scrape-awarded-all');
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+
+      let total = 0;
+      // Display one line per source summarising how many awards were added
+      Object.keys(data).forEach(key => {
+        const { added, error } = data[key];
+        total += added;
+        const li = document.createElement('li');
+        li.textContent = `${key}: ${error ? 'error' : `${added} added`}`;
+        feedEl.appendChild(li);
+      });
+
+      statusEl.textContent = `Added ${total} new awards in total.`;
+      // Leave the page unchanged so the log window stays visible.
+    } catch (err) {
+      statusEl.textContent = 'Error running scraper.';
+    }
+  });
+
+  // Allow users to submit the Add Source form to register a new scraping
+  // location without restarting the server.
+  document.getElementById('addSourceForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const key = document.getElementById('newKey').value.trim();
+    const label = document.getElementById('newLabel').value.trim();
+    const url = document.getElementById('newUrl').value.trim();
+    const base = document.getElementById('newBase').value.trim();
+
+    const res = await fetch('/sources', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key, label, url, base })
+    });
+
+    if (res.ok) {
+      // Reload so the new source appears in the dropdown
+      location.reload();
+    } else {
+      alert('Failed to add source');
+    }
+  });
+  </script>
+</body>
+</html>

--- a/server/config.js
+++ b/server/config.js
@@ -96,6 +96,98 @@ const intendSource = {
   parser: 'rss'
 };
 
+// Sources providing information on awarded contracts. These mirror the
+// structure of the tender sources above but point to award notices instead of
+// current opportunities. URLs are illustrative and may need adjusting for real
+// deployments.
+const defaultAwardSource = {
+  label: 'Contracts Finder Awards',
+  url:
+    process.env.AWARD_URL ||
+    'https://www.contractsfinder.service.gov.uk/RSSFeed.aspx?type=Projects&Status=Awarded',
+  base:
+    process.env.AWARD_BASE ||
+    'https://www.contractsfinder.service.gov.uk',
+  parser: 'rss'
+};
+
+const euSupplyAwardSource = {
+  label: 'EU Supply Awards',
+  url:
+    process.env.EUSUPPLY_AWARD_URL ||
+    'https://uk.eu-supply.com/ctm/award/publiccontracts?B=UK',
+  base: process.env.EUSUPPLY_AWARD_BASE || 'https://uk.eu-supply.com',
+  parser: 'rss'
+};
+
+const sell2walesAwardSource = {
+  label: 'Sell2Wales Awards',
+  url:
+    process.env.SELL2WALES_AWARD_URL ||
+    'https://www.sell2wales.gov.wales/rss/award',
+  base: process.env.SELL2WALES_AWARD_BASE || 'https://www.sell2wales.gov.wales',
+  parser: 'rss'
+};
+
+const ukriAwardSource = {
+  label: 'UKRI Awards',
+  url: process.env.UKRI_AWARD_URL || 'https://www.ukri.org/awards/feed/',
+  base: process.env.UKRI_AWARD_BASE || 'https://www.ukri.org',
+  parser: 'rss'
+};
+
+const pcsAwardSource = {
+  label: 'Scotland Awards',
+  url:
+    process.env.PCS_AWARD_URL ||
+    'https://www.publiccontractsscotland.gov.uk/rss/award.xml',
+  base:
+    process.env.PCS_AWARD_BASE || 'https://www.publiccontractsscotland.gov.uk',
+  parser: 'rss'
+};
+
+const etendersniAwardSource = {
+  label: 'eTenders NI Awards',
+  url:
+    process.env.ETENDERSNI_AWARD_URL ||
+    'https://etendersni.gov.uk/epps/cft/listAward?ext_t=RSS',
+  base: process.env.ETENDERSNI_AWARD_BASE || 'https://etendersni.gov.uk',
+  parser: 'rss'
+};
+
+const etendersieAwardSource = {
+  label: 'eTenders IE Awards',
+  url:
+    process.env.ETENDERSIE_AWARD_URL ||
+    'https://www.etenders.gov.ie/feeds/award',
+  base: process.env.ETENDERSIE_AWARD_BASE || 'https://www.etenders.gov.ie',
+  parser: 'rss'
+};
+
+const procontractAwardSource = {
+  label: 'ProContract Awards',
+  url:
+    process.env.PROCONTRACT_AWARD_URL ||
+    'https://procontract.due-north.com/rss/award.xml',
+  base: process.env.PROCONTRACT_AWARD_BASE || 'https://procontract.due-north.com',
+  parser: 'rss'
+};
+
+const intendAwardSource = {
+  label: 'In-Tend Awards',
+  url:
+    process.env.INTEND_AWARD_URL || 'https://in-tendhost.co.uk/awards/feed/',
+  base: process.env.INTEND_AWARD_BASE || 'https://in-tendhost.co.uk',
+  parser: 'rss'
+};
+
+const tedAwardSource = {
+  label: 'TED Europa',
+  url: process.env.TED_AWARD_URL || 'https://ted.europa.eu/udl?uri=TED/rss/awards',
+  base: process.env.TED_AWARD_BASE || 'https://ted.europa.eu',
+  parser: 'rss'
+};
+
 // Default tagging rules used when none are supplied via the TAG_RULES
 // environment variable. Each tag is associated with a list of keywords that,
 // when present in a tender's title or description, cause the tag to be applied.
@@ -131,6 +223,21 @@ module.exports = {
     etendersie: etendersIEsource,
     procontract: procontractSource,
     intend: intendSource
+  },
+
+  // Awarded contract sources used by the dedicated awards scraper. At least ten
+  // are provided out of the box.
+  awardSources: {
+    default: defaultAwardSource,
+    eusupply: euSupplyAwardSource,
+    sell2wales: sell2walesAwardSource,
+    ukri: ukriAwardSource,
+    pcs: pcsAwardSource,
+    etendersni: etendersniAwardSource,
+    etendersie: etendersieAwardSource,
+    procontract: procontractAwardSource,
+    intend: intendAwardSource,
+    ted: tedAwardSource
   },
 
   // Legacy fields maintained for backwards compatibility. These map to the

--- a/server/scrapeAwarded.js
+++ b/server/scrapeAwarded.js
@@ -1,0 +1,240 @@
+const fetch = require('node-fetch');
+const { parseTenders } = require('./htmlParser');
+const db = require('./db');
+const config = require('./config');
+const logger = require('./logger');
+
+/**
+ * Generate tags for a tender based on the configured keyword rules.
+ * Each rule maps a tag to a list of keywords. If any keyword appears in the
+ * title or description the corresponding tag is added to the result.
+ *
+ * @param {string} title - Tender title
+ * @param {string} desc - Tender description
+ * @returns {string[]} list of tags
+ */
+function generateTags(title, desc) {
+  const tags = [];
+  const text = `${title} ${desc}`.toLowerCase();
+  for (const [tag, keywords] of Object.entries(config.tagRules)) {
+    if (keywords.some(k => text.includes(k.toLowerCase()))) {
+      tags.push(tag);
+    }
+  }
+  return tags;
+}
+
+/**
+ * Scrape the government's Contracts Finder site for the latest tenders.
+ *
+ * @returns {Promise<number>} number of new tenders inserted into the database
+ */
+/**
+ * Run the scraper and optionally report progress for each tender found.
+ *
+ * @param {function(object):void} [onProgress] - Optional callback invoked after
+ *   each tender is processed. Receives an object containing the title, 1-based
+ *   index and total number of tenders.
+ * @param {{url: string, base: string}} [source] - Override the default scrape
+ *   target. This allows the scraper to run against different tender sources.
+ * @returns {Promise<number>} number of new tenders inserted into the database
+ */
+/**
+ * Internal implementation used by both `run` and `runAll`. It mirrors the
+ * current run() behaviour but returns an object describing the outcome so that
+ * callers can access error details when needed.
+ *
+ * @param {function(object):void} [onProgress]
+ * @param {object} [source]
+ * @returns {Promise<{added:number, error?:Error}>}
+ */
+async function runInternal(onProgress, sourceKey, source) {
+  try {
+    // Determine the URL/base for this run. When no source is supplied we
+    // construct an object using the default Contracts Finder settings and the
+    // parser key expected by htmlParser.
+    const src =
+      source || {
+        url: config.awardSources.default.url,
+        base: config.awardSources.default.base,
+        parser: config.awardSources.default.parser || 'contractsFinder',
+        label: config.awardSources.default.label || 'Contracts Finder Awards'
+      };
+
+    // Log the start of the scrape and let any progress listener know which
+    // source is being processed.
+    logger.info(`Starting scrape for ${src.label} (${src.url})`);
+    if (onProgress) {
+      onProgress({ step: 'start', source: src });
+    }
+
+    // Collect tenders from all available pages. Some sources only show a
+    // limited number of results per page so we follow any "next" links until
+    // no further pages remain. This keeps the implementation generic without
+    // hard coding page query parameters.
+    const allTenders = [];
+    let nextUrl = src.url;
+    let page = 1;
+    const headers = {
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36'
+    };
+
+    while (nextUrl) {
+      // Fetch each page sequentially using a browser-like User-Agent.
+      const res = await fetch(nextUrl, { headers });
+      const html = await res.text();
+
+      // Extract tenders from the HTML using the configured parser and add them
+      // to the overall results list.
+      const pageTenders = parseTenders(html, src.parser);
+      logger.info(`Found ${pageTenders.length} tenders on ${src.label} page ${page}`);
+      allTenders.push(...pageTenders);
+
+      // Look for a link pointing to the next page. Many sites mark this with a
+      // rel="next" attribute or anchor text containing "Next". Relative URLs are
+      // resolved against the source base URL so both absolute and relative links
+      // are handled consistently.
+      const relNext = html.match(/<link[^>]*rel=["']next["'][^>]*href=["']([^"']+)["']/i);
+      const anchorNext =
+        html.match(/<a[^>]*href=["']([^"']+)["'][^>]*>(?:Next|next|›|&gt;|&raquo;)/i);
+      const href = relNext ? relNext[1] : anchorNext ? anchorNext[1] : null;
+      nextUrl = href ? new URL(href.replace(/&amp;/g, '&'), src.base).href : null;
+      page += 1;
+    }
+
+    logger.info(`Found ${allTenders.length} tenders on ${src.label}`);
+
+    if (onProgress) {
+      // Report the total number of tenders discovered across all pages.
+      onProgress({ step: 'found', count: allTenders.length });
+    }
+
+    // Track how many tenders were inserted during this run.
+    let count = 0;
+
+    // `allTenders` contains every result from all pages, so we know the total
+    // count before inserting anything.
+    const total = allTenders.length;
+
+    // Iterate over each result and insert it into the database. The
+    // insertTender function resolves with the number of rows inserted so we can
+    // keep track of how many new tenders were added.
+    // Use a single timestamp for all tenders so stats can group them by run.
+    const runTs = new Date().toISOString();
+
+    for (const [i, tender] of allTenders.entries()) {
+      const title = tender.title;
+      const link = src.base + tender.link;
+      const date = tender.date;
+      const desc = tender.desc;
+      const tags = generateTags(title, desc);
+      // Include metadata about where and when the tender was scraped so
+      // the dashboard can display this context to the user.
+      const srcLabel = src.label;
+      const scrapedAt = runTs;
+
+      let inserted = 0;
+      try {
+        // Attempt to store the awarded contract. `insertAward` resolves with 1
+        // when a new record was inserted or 0 if it already existed.
+        inserted = await db.insertAward(
+          title,
+          link,
+          date,
+          desc,
+          srcLabel,
+          scrapedAt,
+          tags.join(',')
+        );
+
+        if (inserted) {
+          count += 1;
+        }
+      } catch (err) {
+        // Log database errors but continue processing the remaining tenders.
+        logger.error('Error inserting award:', err);
+      }
+
+      // Log progress for debugging purposes and notify listeners so the UI can
+      // update in real time.
+      logger.info(
+        `[${i + 1}/${total}] ${title} - ${inserted ? 'inserted' : 'duplicate'}`
+      );
+      if (onProgress) {
+        onProgress({
+          step: 'tender',
+          title,
+          index: i + 1,
+          total,
+          inserted: Boolean(inserted)
+        });
+      }
+    }
+
+    // Record when this scrape completed successfully so the UI can show
+    // freshness information. Failures in this step should not abort the run.
+    try {
+      // Persist overall and per-source timestamps for the admin UI.
+      await db.setLastScraped(runTs);
+      if (sourceKey) {
+        await db.updateSourceStats(sourceKey, runTs, count);
+      }
+    } catch (err) {
+      logger.error('Failed to update last_scraped timestamp:', err);
+    }
+
+    // Provide additional debug output when no new tenders were stored so that
+    // any issues with the parser or source can be investigated more easily.
+    if (count === 0) {
+      if (allTenders.length === 0) {
+        logger.info(`No tenders were returned for ${src.label}`);
+      } else {
+        logger.info(
+          `${allTenders.length} tenders found on ${src.label} but all were duplicates`
+        );
+      }
+    } else {
+      logger.info(`Inserted ${count} new tenders from ${src.label}`);
+    }
+
+    // Return the number of newly inserted tenders.
+    return { added: count };
+  } catch (err) {
+    // Network or parsing errors end up here. Return 0 to indicate no new data
+    // was stored during this run and expose the error so callers can log it.
+    logger.error('Error fetching tenders from', source?.label || 'default', ':', err);
+    return { added: 0, error: err };
+  }
+}
+
+/**
+ * Public wrapper matching the original API used throughout the codebase. This
+ * preserves backwards compatibility while allowing runAll() to obtain error
+ * information from runInternal.
+ */
+module.exports.run = async function (onProgress, source, sourceKey = 'default') {
+  const result = await runInternal(onProgress, sourceKey, source);
+  return result.added;
+};
+
+/**
+ * Scrape all configured sources one after another. The returned object maps the
+ * source key to the result of each run.
+ *
+ * @param {function(object):void} [onProgress]
+ * @returns {Promise<Object>} results keyed by source key
+ */
+module.exports.runAll = async function (onProgress) {
+  logger.info('Starting scrape for all configured award sources');
+  const results = {};
+  for (const [key, src] of Object.entries(config.awardSources)) {
+    const progress = p => onProgress && onProgress({ source: key, ...p });
+    const res = await runInternal(progress, key, src);
+    if (res.error) {
+      logger.error(`Scrape failed for ${key}:`, res.error);
+    }
+    results[key] = { added: res.added, error: res.error && res.error.message };
+  }
+  return results;
+};


### PR DESCRIPTION
## Summary
- rename main dashboard page to **Available Contracts**
- add new page and routes for **Awarded Contracts**
- implement award scraper with at least ten award sources
- extend database schema with awards table and helpers
- expose endpoints to scrape awarded contract feeds

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645c91687883289ddb5d5e0ec8f5eb