### PR TITLE
Fix scrape-all UI refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ This application scrapes new tenders from several procurement portals including 
 - **Run the scraper** by selecting a source from the drop-down list and clicking
   **Scrape**. Progress messages stream to the page and new tenders appear in the
   results table.
-- **Scrape all sources** at once by visiting `/scrape-all`. Each source is
-  processed sequentially and the response details which succeeded or failed.
+ - **Scrape all sources** at once by visiting `/scrape-all`. Each source is
+    processed sequentially and the response details which succeeded or failed.
+    The page automatically reloads once scraping completes so the table reflects
+    any new tenders that were stored.
 - **Add a source** using the *Add Source* form. Provide a key, label, search URL
   and base URL. Once submitted the new source is added immediately for the
   current session and saved to the database so it is available after restarting

--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -147,7 +147,9 @@
       });
 
       statusEl.textContent = `Added ${total} new tenders in total.`;
-      // Leave the page unchanged so the log window stays visible.
+      // Refresh the page so the results table shows newly inserted tenders.
+      // A short delay keeps the summary visible briefly before reloading.
+      setTimeout(() => location.reload(), 1000);
     } catch (err) {
       statusEl.textContent = 'Error running scraper.';
     }


### PR DESCRIPTION
## Summary
- refresh dashboard after scraping all sources
- document that scrape-all reloads the page

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645dfc6fd08328a428fe5f03c8dc5f