### PR TITLE
Add suppliers and customers pages

### DIFF
--- a/frontend/available.ejs
+++ b/frontend/available.ejs
@@ -13,6 +13,8 @@
     <a href="/login">Login</a> |
   <% } %>
   <a href="/awarded">Awarded Contracts</a> |
+  <a href="/customers">Customers</a> |
+  <a href="/suppliers">Suppliers</a> |
   <!-- Link to the statistics page showing when the scraper last ran -->
   <a href="/stats">Stats</a>
   <!-- Brief instructions help new users understand the workflow -->

--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -13,6 +13,8 @@
     <a href="/login">Login</a> |
   <% } %>
   <a href="/">Available Contracts</a> |
+  <a href="/customers">Customers</a> |
+  <a href="/suppliers">Suppliers</a> |
   <!-- Link to the statistics page showing when the scraper last ran -->
   <a href="/stats">Stats</a>
   <!-- Brief instructions help new users understand the workflow -->

--- a/frontend/customers.ejs
+++ b/frontend/customers.ejs
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Customers</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Customers</h1>
+  <a href="/">Available Contracts</a> |
+  <a href="/awarded">Awarded Contracts</a> |
+  <a href="/suppliers">Suppliers</a> |
+  <a href="/stats">Stats</a>
+  <table>
+    <tr><th>Name</th></tr>
+    <% organisations.forEach(o => { %>
+      <tr><td><%= o.name %></td></tr>
+    <% }) %>
+  </table>
+</body>
+</html>

--- a/frontend/suppliers.ejs
+++ b/frontend/suppliers.ejs
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Suppliers</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Suppliers</h1>
+  <a href="/">Available Contracts</a> |
+  <a href="/awarded">Awarded Contracts</a> |
+  <a href="/customers">Customers</a> |
+  <a href="/stats">Stats</a>
+  <table>
+    <tr><th>Name</th></tr>
+    <% organisations.forEach(o => { %>
+      <tr><td><%= o.name %></td></tr>
+    <% }) %>
+  </table>
+</body>
+</html>

--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -26,8 +26,15 @@ function parseContractsFinder(html) {
       /<span[^>]*class="[^"]*date[^"]*"[^>]*>(.*?)<\/span>/i.exec(block);
     const date = dateMatch ? clean(dateMatch[1]) : '';
     const desc = clean(/<p[^>]*>(.*?)<\/p>/i.exec(block)?.[1] || '');
+    // Look for an organisation or supplier name within the block
+    const orgMatch =
+      /<span[^>]*class="[^"]*org[^"]*"[^>]*>(.*?)<\/span>/i.exec(block);
+    const supplierMatch =
+      /<span[^>]*class="[^"]*supplier[^"]*"[^>]*>(.*?)<\/span>/i.exec(block);
+    const organisation = orgMatch ? clean(orgMatch[1]) : '';
+    const supplier = supplierMatch ? clean(supplierMatch[1]) : '';
     if (href && title) {
-      tenders.push({ title, link: href, date, desc });
+      tenders.push({ title, link: href, date, desc, organisation, supplier });
     }
   }
   return tenders;
@@ -57,8 +64,10 @@ function parseSell2Wales(html) {
         /<p[^>]*>([\s\S]*?)<\/p>/i.exec(block)?.[1] ||
         ''
     );
+    const organisation = '';
+    const supplier = '';
     if (title && href) {
-      tenders.push({ title, link: href, date, desc });
+      tenders.push({ title, link: href, date, desc, organisation, supplier });
     }
   }
   return tenders;
@@ -82,8 +91,10 @@ function parseUkri(html) {
     const href = link[1];
     const date = clean(/<time[^>]*>(.*?)<\/time>/i.exec(block)?.[1] || '');
     const desc = clean(/<p[^>]*>([\s\S]*?)<\/p>/i.exec(block)?.[1] || '');
+    const organisation = '';
+    const supplier = '';
     if (!/contact\s+us/i.test(title)) {
-      tenders.push({ title, link: href, date, desc });
+      tenders.push({ title, link: href, date, desc, organisation, supplier });
     }
   }
   return tenders;
@@ -105,7 +116,9 @@ function parseEuSupply(html) {
     const href = link[1];
     const date = /(\d{2}\/\d{2}\/\d{4}|\d{4}-\d{2}-\d{2})/.exec(block)?.[1] || '';
     const desc = /<td[^>]*class="description"[^>]*>(.*?)<\/td>/.exec(block)?.[1].trim() || '';
-    tenders.push({ title, link: href, date, desc });
+    const organisation = '';
+    const supplier = '';
+    tenders.push({ title, link: href, date, desc, organisation, supplier });
   }
   return tenders;
 }
@@ -124,8 +137,10 @@ function parseRss(xml) {
     const href = clean(/<link>([\s\S]*?)<\/link>/i.exec(block)?.[1] || '');
     const date = clean(/<(pubDate|dc:date)>([\s\S]*?)<\/(pubDate|dc:date)>/i.exec(block)?.[2] || '');
     const desc = clean(/<description>([\s\S]*?)<\/description>/i.exec(block)?.[1] || '');
+    const organisation = '';
+    const supplier = '';
     if (title && href) {
-      tenders.push({ title, link: href, date, desc });
+      tenders.push({ title, link: href, date, desc, organisation, supplier });
     }
   }
   return tenders;

--- a/server/index.js
+++ b/server/index.js
@@ -106,6 +106,17 @@ app.get('/stats', async (req, res) => {
   res.render('stats', { lastScraped });
 });
 
+// Lists of organisations scraped from tender sources
+app.get('/customers', async (req, res) => {
+  const organisations = await db.getOrganisationsByType('customer');
+  res.render('customers', { organisations });
+});
+
+app.get('/suppliers', async (req, res) => {
+  const organisations = await db.getOrganisationsByType('supplier');
+  res.render('suppliers', { organisations });
+});
+
 // Authentication -----------------------------------------------------------
 
 // Render login form

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -141,6 +141,7 @@ async function runInternal(onProgress, sourceKey, source) {
       const link = src.base + tender.link;
       const date = tender.date;
       const desc = tender.desc;
+      const organisation = tender.organisation;
       const tags = generateTags(title, desc);
       // Include metadata about where and when the tender was scraped so
       // the dashboard can display this context to the user.
@@ -163,6 +164,13 @@ async function runInternal(onProgress, sourceKey, source) {
 
         if (inserted) {
           count += 1;
+          if (organisation) {
+            try {
+              await db.insertOrganisation(organisation, 'customer');
+            } catch (err) {
+              logger.error('Error inserting organisation:', err);
+            }
+          }
         }
       } catch (err) {
         // Log database errors but continue processing the remaining tenders.

--- a/server/scrapeAwarded.js
+++ b/server/scrapeAwarded.js
@@ -128,6 +128,7 @@ async function runInternal(onProgress, sourceKey, source) {
       const link = src.base + tender.link;
       const date = tender.date;
       const desc = tender.desc;
+      const supplier = tender.supplier;
       const tags = generateTags(title, desc);
       // Include metadata about where and when the tender was scraped so
       // the dashboard can display this context to the user.
@@ -150,6 +151,13 @@ async function runInternal(onProgress, sourceKey, source) {
 
         if (inserted) {
           count += 1;
+          if (supplier) {
+            try {
+              await db.insertOrganisation(supplier, 'supplier');
+            } catch (err) {
+              logger.error('Error inserting organisation:', err);
+            }
+          }
         }
       } catch (err) {
         // Log database errors but continue processing the remaining tenders.

--- a/test/mock.html
+++ b/test/mock.html
@@ -1,11 +1,15 @@
 <div class="search-result">
   <h2>Contract 1</h2>
+  <span class="org">Org1</span>
+  <span class="supplier">Sup1</span>
   <a href="/c1"></a>
   <span class="date">2024-04-01</span>
   <p>Description 1</p>
 </div>
 <div class="search-result">
   <h2>Contract 2</h2>
+  <span class="org">Org2</span>
+  <span class="supplier">Sup2</span>
   <a href="/c2"></a>
   <span class="date">2024-05-01</span>
   <p>Description 2</p>

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -6,12 +6,16 @@ describe('htmlParser', () => {
     const html = `
       <div class="search-result">
         <h2>Contract A</h2>
+        <span class="org">OrgA</span>
+        <span class="supplier">SupA</span>
         <a href="/cA">View</a>
         <span class="date">2024-01-01</span>
         <p>Desc A</p>
       </div>
       <div class="search-result">
         <a href="/cB">Contract B</a>
+        <span class="org">OrgB</span>
+        <span class="supplier">SupB</span>
         <time>2024-02-01</time>
         <p>Desc B</p>
       </div>`;
@@ -19,6 +23,8 @@ describe('htmlParser', () => {
     expect(tenders).to.have.length(2);
     expect(tenders[0].title).to.equal('Contract A');
     expect(tenders[1].title).to.equal('Contract B');
+    expect(tenders[0].organisation).to.equal('OrgA');
+    expect(tenders[0].supplier).to.equal('SupA');
   });
 
   it('parses Sell2Wales table rows', () => {

--- a/test/scrape.test.js
+++ b/test/scrape.test.js
@@ -34,5 +34,9 @@ describe('scrape.run', () => {
     expect(rows[0]).to.have.property('tags');
     const ts = await db.getLastScraped();
     expect(ts).to.be.a('string');
+    const cust = await db.getOrganisationsByType('customer');
+    const supp = await db.getOrganisationsByType('supplier');
+    expect(cust).to.have.length(2);
+    expect(supp).to.have.length(2);
   });
 });


### PR DESCRIPTION
## Summary
- scrape organisation names from tender listings
- track organisations in a new database table
- add suppliers/customers pages with organisation tables
- show the new pages in navigation links
- extend scrapers and HTML parser to detect organisation data
- tests updated for new fields

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653321883883288ad6359333c62ed2