### PR TITLE
Fix scrape-all table refresh and URL building

### DIFF
--- a/frontend/available.ejs
+++ b/frontend/available.ejs
@@ -150,7 +150,9 @@
       });
 
       statusEl.textContent = `Added ${total} new tenders in total.`;
-      // Leave the page unchanged so the log window stays visible.
+      // Reload the page so the table reflects the newly stored tenders.
+      // The feed remains visible until the reload occurs.
+      location.reload();
     } catch (err) {
       statusEl.textContent = 'Error running scraper.';
     }

--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -150,7 +150,8 @@
       });
 
       statusEl.textContent = `Added ${total} new awards in total.`;
-      // Leave the page unchanged so the log window stays visible.
+      // Reload so the awards table shows the latest results.
+      location.reload();
     } catch (err) {
       statusEl.textContent = 'Error running scraper.';
     }

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -138,7 +138,11 @@ async function runInternal(onProgress, sourceKey, source) {
 
     for (const [i, tender] of allTenders.entries()) {
       const title = tender.title;
-      const link = src.base + tender.link;
+      // Combine the base URL with the scraped link, handling both
+      // absolute and relative hrefs using the URL constructor. This
+      // avoids malformed URLs when the feed already provides an
+      // absolute link.
+      const link = new URL(tender.link, src.base).href;
       const date = tender.date;
       const desc = tender.desc;
       const organisation = tender.organisation;

--- a/server/scrapeAwarded.js
+++ b/server/scrapeAwarded.js
@@ -125,7 +125,10 @@ async function runInternal(onProgress, sourceKey, source) {
 
     for (const [i, tender] of allTenders.entries()) {
       const title = tender.title;
-      const link = src.base + tender.link;
+      // Normalise tender links using the base URL so relative and
+      // absolute URLs are handled consistently. This prevents malformed
+      // links in the stored data.
+      const link = new URL(tender.link, src.base).href;
       const date = tender.date;
       const desc = tender.desc;
       const supplier = tender.supplier;


### PR DESCRIPTION
## Summary
- normalise tender links using URL constructor
- reload dashboard pages after scraping

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686542717e3c8328b77233826cc9c2c6