### PR TITLE
Enhance log visibility and progress

### DIFF
--- a/frontend/available.ejs
+++ b/frontend/available.ejs
@@ -91,25 +91,31 @@
       src.onmessage = e => {
         const data = JSON.parse(e.data);
 
-        if (data.start) {
+        if (data.step === 'start' || data.start) {
           // Initial event tells us which source is being scraped.
           statusEl.textContent = `Scraping from ${data.source}...`;
+        } else if (data.step === 'page') {
+          // Inform the user which page is currently being fetched.
+          statusEl.textContent =
+            `Fetching page ${data.page} (elapsed ${data.elapsed}s)...`;
         } else if (data.step === 'found') {
-          // The scraper has parsed the page and knows how many tenders exist.
+          // The scraper has parsed all pages and knows how many tenders exist.
           statusEl.textContent = `Found ${data.count} tenders.`;
         } else if (data.step === 'tender') {
           // Update the rolling feed with each tender processed.
           const li = document.createElement('li');
           li.textContent = `(${data.index}/${data.total}) ${data.title} - ${
-            data.inserted ? 'added' : 'skipped'}`;
+            data.inserted ? 'added' : 'skipped'} (${data.elapsed}s)`;
           feedEl.appendChild(li);
         } else if (data.done) {
           // Final event - display a summary but keep the log visible so the
           // user can review it without the page refreshing.
           if (data.added === 0) {
-            statusEl.textContent = 'No new tenders found.';
+            statusEl.textContent =
+              `No new tenders found (completed in ${data.duration}s).`;
           } else {
-            statusEl.textContent = `Added ${data.added} new tenders.`;
+            statusEl.textContent =
+              `Added ${data.added} new tenders in ${data.duration}s.`;
           }
           // Close the SSE connection; the page is left intact so the logs
           // remain available.
@@ -149,10 +155,8 @@
         feedEl.appendChild(li);
       });
 
-      statusEl.textContent = `Added ${total} new tenders in total.`;
-      // Reload the page so the table reflects the newly stored tenders.
-      // The feed remains visible until the reload occurs.
-      location.reload();
+      statusEl.textContent =
+        `Added ${total} new tenders in total. Refresh the page to see them.`;
     } catch (err) {
       statusEl.textContent = 'Error running scraper.';
     }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -32,6 +32,7 @@ tr:nth-child(even) {
   overflow-y: auto;
   border: 1px solid #ccc;
   padding-left: 1rem;
+  min-height: 2em;
 }
 
 /* Small layout tweaks for the add-source form */


### PR DESCRIPTION
## Summary
- keep tender feed area visible
- show page and timing info while scraping
- include durations in SSE endpoints
- update dashboard to display extra progress data and avoid auto reload

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666c1ec984832896a492e090c7493d