### PR TITLE
Add award detail scraping

### DIFF
--- a/server/detailParser.js
+++ b/server/detailParser.js
@@ -1,0 +1,96 @@
+// Parser for detailed award pages. Extracts structured fields from
+// page text so results can be stored consistently across sources.
+// The input is expected to be HTML or plain text containing headings
+// like "Location of contract" followed by the corresponding value on
+// the next line. The parser returns an object with keys matching the
+// database columns used to store additional award information.
+
+function parseAwardDetails(html) {
+  // Strip HTML tags and normalise line endings to simplify regex matching.
+  const text = html.replace(/<[^>]*>/g, '').replace(/\r/g, '');
+  const lines = text.split(/\n+/).map(l => l.trim()).filter(Boolean);
+  const out = {};
+
+  // Helper to read the value immediately after a label. Many fields are
+  // presented on the next line so we locate the label and take the
+  // subsequent line as the value.
+  const valueAfter = label => {
+    const idx = lines.findIndex(l => l.toLowerCase() === label.toLowerCase());
+    return idx !== -1 && lines[idx + 1] ? lines[idx + 1] : '';
+  };
+
+  // Extract simple one line fields.
+  out.buyer = lines[1] || '';
+  out.status = (text.match(/(Open opportunity|Closed opportunity|Awarded)/i) || [])[0] || '';
+  out.industry = (() => {
+    const start = lines.findIndex(l => l.toLowerCase() === 'industry');
+    if (start === -1) return '';
+    const values = [];
+    for (let i = start + 1; i < lines.length; i++) {
+      const l = lines[i];
+      if (/^(location of contract|value of contract|procurement reference|published date|closing date|closing time|contract start date|contract end date|contract type|procedure type)/i.test(l)) break;
+      values.push(l);
+    }
+    return values.join('; ');
+  })();
+  out.location = valueAfter('Location of contract');
+  out.value = valueAfter('Value of contract');
+  out.procurement_reference = valueAfter('Procurement reference');
+  out.closing_date = valueAfter('Closing date');
+  out.closing_time = valueAfter('Closing time');
+  out.start_date = valueAfter('Contract start date');
+  out.end_date = valueAfter('Contract end date');
+  out.contract_type = valueAfter('Contract type');
+  out.procedure_type = valueAfter('Procedure type');
+  out.procedure_desc = (() => {
+    const idx = lines.findIndex(l => /^what is/i.test(l));
+    if (idx === -1) return '';
+    const vals = [];
+    for (let i = idx + 1; i < lines.length; i++) {
+      const l = lines[i];
+      if (/^contract is suitable/i.test(l)) break;
+      vals.push(l);
+    }
+    return vals.join(' ');
+  })();
+  out.suitable_for_sme = valueAfter('Contract is suitable for SMEs?').toLowerCase() === 'yes';
+  out.suitable_for_vcse = valueAfter('Contract is suitable for VCSEs?').toLowerCase() === 'yes';
+  out.description = (() => {
+    const start = lines.findIndex(l => l.toLowerCase() === 'description');
+    if (start === -1) return '';
+    const vals = [];
+    for (let i = start + 1; i < lines.length; i++) {
+      const l = lines[i];
+      if (l.toLowerCase() === 'how to apply') break;
+      vals.push(l);
+    }
+    return vals.join(' ');
+  })();
+  out.how_to_apply = (() => {
+    const start = lines.findIndex(l => l.toLowerCase() === 'how to apply');
+    if (start === -1) return '';
+    const vals = [];
+    for (let i = start + 1; i < lines.length; i++) {
+      const l = lines[i];
+      if (l.toLowerCase() === 'about the buyer') break;
+      vals.push(l);
+    }
+    return vals.join(' ');
+  })();
+  out.buyer_address = (() => {
+    const start = lines.findIndex(l => l.toLowerCase() === 'address');
+    if (start === -1) return '';
+    const vals = [];
+    for (let i = start + 1; i < lines.length; i++) {
+      const l = lines[i];
+      if (l.toLowerCase() === 'email') break;
+      vals.push(l);
+    }
+    return vals.join(', ');
+  })();
+  out.buyer_email = valueAfter('Email');
+
+  return out;
+}
+
+module.exports = { parseAwardDetails };

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -28,6 +28,38 @@ db.serialize(() => {
     scraped_at TEXT,
     tags TEXT
   )`);
+  db.run(`CREATE TABLE IF NOT EXISTS awards (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    link TEXT UNIQUE,
+    date TEXT,
+    description TEXT,
+    source TEXT,
+    scraped_at TEXT,
+    tags TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS award_details (
+    award_id INTEGER PRIMARY KEY,
+    buyer TEXT,
+    status TEXT,
+    industry TEXT,
+    location TEXT,
+    value TEXT,
+    procurement_reference TEXT,
+    closing_date TEXT,
+    closing_time TEXT,
+    start_date TEXT,
+    end_date TEXT,
+    contract_type TEXT,
+    procedure_type TEXT,
+    procedure_desc TEXT,
+    suitable_for_sme INTEGER,
+    suitable_for_vcse INTEGER,
+    how_to_apply TEXT,
+    buyer_address TEXT,
+    buyer_email TEXT,
+    FOREIGN KEY(award_id) REFERENCES awards(id)
+  )`);
   db.run(`CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -87,4 +87,25 @@ describe('Database helpers', () => {
     expect(s.total).to.equal(5);
     expect(s.last_added).to.equal(2);
   });
+
+  it('award details can be stored and retrieved', async () => {
+    const res = await db.insertAward(
+      'a',
+      'linka',
+      '2024-06-01',
+      'desc',
+      'src',
+      '2024-06-02T00:00:00Z',
+      't'
+    );
+    await db.insertAwardDetails(res.id, {
+      buyer: 'Buyer',
+      value: '100',
+      location: 'X'
+    });
+    const row = await db.getAwardDetails(res.id);
+    expect(row.buyer).to.equal('Buyer');
+    expect(row.value).to.equal('100');
+    expect(row.location).to.equal('X');
+  });
 });

--- a/test/detailParser.test.js
+++ b/test/detailParser.test.js
@@ -1,0 +1,67 @@
+const { expect } = require('chai');
+const { parseAwardDetails } = require('../server/detailParser');
+
+describe('parseAwardDetails', () => {
+  it('extracts fields from award page text', () => {
+    const text = `M6 Lune Gorge - Bird Netting/ Tree Netting
+KIER TRANSPORTATION LIMITED
+Published date: 3 July 2025
+
+Open opportunity - This means that the contract is currently active.
+
+Contract summary
+Industry
+Cordage, rope, twine and netting - 39541000
+
+Location of contract
+CA10 3XR
+
+Value of contract
+£300,000
+
+Procurement reference
+ABC123
+
+Closing date
+10 July 2025
+
+Closing time
+5pm
+
+Contract start date
+21 August 2025
+
+Contract end date
+1 October 2025
+
+Contract type
+Works
+
+Procedure type
+Competitive quotation (below threshold)
+What is a competitive quotation (below threshold)?
+Bidders submit quotes.
+Contract is suitable for SMEs?
+Yes
+Contract is suitable for VCSEs?
+No
+Description
+Work on bridge structures.
+How to apply
+Follow instructions.
+About the buyer
+Address
+2nd Floor Optimum House
+SALFORD
+M503XP
+England
+Email
+transportationprocurement@kier.co.uk`;
+    const d = parseAwardDetails(text);
+    expect(d.value).to.equal('£300,000');
+    expect(d.location).to.equal('CA10 3XR');
+    expect(d.contract_type).to.equal('Works');
+    expect(d.suitable_for_sme).to.equal(true);
+    expect(d.buyer_email).to.equal('transportationprocurement@kier.co.uk');
+  });
+});


### PR DESCRIPTION
## Summary
- add parser for award detail pages
- store additional award details in new award_details table
- scrape detail pages in awards scraper and save structured info
- initialise new tables and update database reset logic
- test award detail parser and new DB helpers

## Testing
- `npm test` *(fails: mocha could not be run because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68666dacc2408328853288ab773da991