### PR TITLE
Persist session cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This application scrapes new tenders from several procurement portals including 
 - **Edit or delete sources** from the admin page. Use the list of configured
   sources to modify details or remove entries entirely.
 - **Manage the application** by registering at `/register`, logging in at
-  `/login` and visiting `/admin`. Only authenticated users can access admin
-  functions.
+  `/login` and visiting `/admin`. Once logged in your session persists for 30 days so you remain authenticated after closing the browser. Only
+  authenticated users can access admin functions.
 - **Automatic scraping** runs in the background according to the `CRON_SCHEDULE`
   environment variable (default `0 6 * * *`). Results are stored in the
   database without any manual interaction.

--- a/server/index.js
+++ b/server/index.js
@@ -62,7 +62,11 @@ app.use(
   session({
     secret: process.env.SESSION_SECRET || 'change_this_secret',
     resave: false,
-    saveUninitialized: false
+    saveUninitialized: false,
+    // Persist the session cookie for 30 days so users remain logged in
+    // even after closing the browser. The in-memory store still means
+    // sessions are lost if the server restarts.
+    cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 }
   })
 );
 


### PR DESCRIPTION
## Summary
- persist session cookies for 30 days
- document session behaviour in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667d21ef288328ab286026364d6cbe