### PR TITLE
Add OCID dedupe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ the source being scraped, how many tenders were discovered and whether each one
 was added to the database or skipped as a duplicate. A final message summarises
 how many new tenders were stored.
 
+Each tender is deduplicated using its link and, when available, the procurement
+identifier (OCID) extracted from the listing. This prevents multiple entries for
+the same opportunity even if the URL changes between runs.
+
 ## Statistics
 
 The `/stats` page displays when the scraper last completed successfully. This

--- a/server/db.js
+++ b/server/db.js
@@ -22,6 +22,7 @@ db.serialize(() => {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT,
     link TEXT UNIQUE,
+    ocid TEXT UNIQUE,
     date TEXT,
     description TEXT,
     /* Source site label */
@@ -130,12 +131,21 @@ module.exports = {
    * @param {string} tags - Comma separated tags for the tender
    * @returns {Promise<number>} resolves with 1 when inserted or 0 if skipped
    */
-  insertTender: (title, link, date, description, source, scrapedAt, tags) => {
+  insertTender: (
+    title,
+    link,
+    date,
+    description,
+    source,
+    scrapedAt,
+    tags,
+    ocid = null
+  ) => {
     return new Promise((resolve, reject) => {
       db.run(
-        // Use INSERT OR IGNORE so that duplicate links are skipped silently.
-        "INSERT OR IGNORE INTO tenders (title, link, date, description, source, scraped_at, tags) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        [title, link, date, description, source, scrapedAt, tags],
+        // Use INSERT OR IGNORE so that duplicate links or OCIDs are skipped silently.
+        "INSERT OR IGNORE INTO tenders (title, link, ocid, date, description, source, scraped_at, tags) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [title, link, ocid, date, description, source, scrapedAt, tags],
         function (err) {
           if (err) {
             // Propagate database errors to the caller.
@@ -559,6 +569,7 @@ module.exports = {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title TEXT,
             link TEXT UNIQUE,
+            ocid TEXT UNIQUE,
             date TEXT,
             description TEXT,
             source TEXT,

--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -33,8 +33,21 @@ function parseContractsFinder(html) {
       /<span[^>]*class="[^"]*supplier[^"]*"[^>]*>(.*?)<\/span>/i.exec(block);
     const organisation = orgMatch ? clean(orgMatch[1]) : '';
     const supplier = supplierMatch ? clean(supplierMatch[1]) : '';
+    // Attempt to find an Open Contracting ID (OCID) within the block. Many
+    // sources embed this either as a data attribute or plain text string.
+    const ocidMatch =
+      block.match(/data-ocid="([^"]+)"/i) || block.match(/(ocds-[a-z0-9-]+)/i);
+    const ocid = ocidMatch ? ocidMatch[1] || ocidMatch[0] : '';
     if (href && title) {
-      tenders.push({ title, link: href, date, desc, organisation, supplier });
+      tenders.push({
+        title,
+        link: href,
+        date,
+        desc,
+        organisation,
+        supplier,
+        ocid
+      });
     }
   }
   return tenders;
@@ -66,8 +79,11 @@ function parseSell2Wales(html) {
     );
     const organisation = '';
     const supplier = '';
+    const ocidMatch =
+      block.match(/data-ocid="([^"]+)"/i) || block.match(/(ocds-[a-z0-9-]+)/i);
+    const ocid = ocidMatch ? ocidMatch[1] || ocidMatch[0] : '';
     if (title && href) {
-      tenders.push({ title, link: href, date, desc, organisation, supplier });
+      tenders.push({ title, link: href, date, desc, organisation, supplier, ocid });
     }
   }
   return tenders;
@@ -93,8 +109,11 @@ function parseUkri(html) {
     const desc = clean(/<p[^>]*>([\s\S]*?)<\/p>/i.exec(block)?.[1] || '');
     const organisation = '';
     const supplier = '';
+    const ocidMatch =
+      block.match(/data-ocid="([^"]+)"/i) || block.match(/(ocds-[a-z0-9-]+)/i);
+    const ocid = ocidMatch ? ocidMatch[1] || ocidMatch[0] : '';
     if (!/contact\s+us/i.test(title)) {
-      tenders.push({ title, link: href, date, desc, organisation, supplier });
+      tenders.push({ title, link: href, date, desc, organisation, supplier, ocid });
     }
   }
   return tenders;
@@ -118,7 +137,10 @@ function parseEuSupply(html) {
     const desc = /<td[^>]*class="description"[^>]*>(.*?)<\/td>/.exec(block)?.[1].trim() || '';
     const organisation = '';
     const supplier = '';
-    tenders.push({ title, link: href, date, desc, organisation, supplier });
+    const ocidMatch =
+      block.match(/data-ocid="([^"]+)"/i) || block.match(/(ocds-[a-z0-9-]+)/i);
+    const ocid = ocidMatch ? ocidMatch[1] || ocidMatch[0] : '';
+    tenders.push({ title, link: href, date, desc, organisation, supplier, ocid });
   }
   return tenders;
 }
@@ -139,8 +161,11 @@ function parseRss(xml) {
     const desc = clean(/<description>([\s\S]*?)<\/description>/i.exec(block)?.[1] || '');
     const organisation = '';
     const supplier = '';
+    const ocidMatch =
+      block.match(/<ocid>([^<]+)<\/ocid>/i) || block.match(/(ocds-[a-z0-9-]+)/i);
+    const ocid = ocidMatch ? ocidMatch[1] || ocidMatch[0] : '';
     if (title && href) {
-      tenders.push({ title, link: href, date, desc, organisation, supplier });
+      tenders.push({ title, link: href, date, desc, organisation, supplier, ocid });
     }
   }
   return tenders;

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -22,6 +22,7 @@ db.serialize(() => {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT,
     link TEXT UNIQUE,
+    ocid TEXT UNIQUE,
     date TEXT,
     description TEXT,
     source TEXT,

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -168,6 +168,7 @@ async function runInternal(onProgress, sourceKey, source) {
       const date = tender.date;
       const desc = tender.desc;
       const organisation = tender.organisation;
+      const ocid = tender.ocid || null;
       const tags = generateTags(title, desc);
       // Include metadata about where and when the tender was scraped so
       // the dashboard can display this context to the user.
@@ -185,7 +186,8 @@ async function runInternal(onProgress, sourceKey, source) {
           desc,
           srcLabel,
           scrapedAt,
-          tags.join(',')
+          tags.join(','),
+          ocid
         );
 
         if (inserted) {

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -16,7 +16,8 @@ describe('Database helpers', () => {
       'desc',
       'source',
       '2024-01-02T00:00:00Z',
-      'tag1'
+      'tag1',
+      'ocds-x'
     );
     const second = await db.insertTender(
       't1',
@@ -25,7 +26,33 @@ describe('Database helpers', () => {
       'desc',
       'source',
       '2024-01-02T00:00:00Z',
-      'tag1'
+      'tag1',
+      'ocds-x'
+    );
+    expect(first).to.equal(1);
+    expect(second).to.equal(0);
+  });
+
+  it('insertTender dedupes on OCID', async () => {
+    const first = await db.insertTender(
+      'tO',
+      'linkO1',
+      '2024-01-01',
+      'd',
+      's',
+      '2024-01-02T00:00:00Z',
+      '',
+      'ocds-dedupe'
+    );
+    const second = await db.insertTender(
+      'tO2',
+      'linkO2',
+      '2024-01-02',
+      'd',
+      's',
+      '2024-01-03T00:00:00Z',
+      '',
+      'ocds-dedupe'
     );
     expect(first).to.equal(1);
     expect(second).to.equal(0);
@@ -33,8 +60,8 @@ describe('Database helpers', () => {
 
   it('getTenders retrieves rows ordered by date', async () => {
     // Insert two tenders with different dates
-    await db.insertTender('t2', 'link2', '2024-02-01', 'd', 's', '2024-02-02T00:00:00Z', 'tag');
-    await db.insertTender('t3', 'link3', '2024-03-01', 'd', 's', '2024-03-02T00:00:00Z', 'tag');
+    await db.insertTender('t2', 'link2', '2024-02-01', 'd', 's', '2024-02-02T00:00:00Z', 'tag', 'ocds-2');
+    await db.insertTender('t3', 'link3', '2024-03-01', 'd', 's', '2024-03-02T00:00:00Z', 'tag', 'ocds-3');
     const rows = await db.getTenders();
     expect(rows).to.have.length(3);
     // Ensure ordering by descending date
@@ -44,6 +71,7 @@ describe('Database helpers', () => {
     expect(rows[0].source).to.be.a('string');
     expect(rows[0].scraped_at).to.be.a('string');
     expect(rows[0]).to.have.property('tags');
+    expect(rows[0]).to.have.property('ocid');
   });
 
   it('cron schedule can be stored and retrieved', async () => {

--- a/test/mock.html
+++ b/test/mock.html
@@ -2,7 +2,7 @@
   <h2>Contract 1</h2>
   <span class="org">Org1</span>
   <span class="supplier">Sup1</span>
-  <a href="/c1"></a>
+  <a href="/c1" data-ocid="ocds-1"></a>
   <span class="date">2024-04-01</span>
   <p>Description 1</p>
 </div>
@@ -10,7 +10,7 @@
   <h2>Contract 2</h2>
   <span class="org">Org2</span>
   <span class="supplier">Sup2</span>
-  <a href="/c2"></a>
+  <a href="/c2" data-ocid="ocds-2"></a>
   <span class="date">2024-05-01</span>
   <p>Description 2</p>
 </div>

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -8,12 +8,12 @@ describe('htmlParser', () => {
         <h2>Contract A</h2>
         <span class="org">OrgA</span>
         <span class="supplier">SupA</span>
-        <a href="/cA">View</a>
+        <a href="/cA" data-ocid="ocds-a">View</a>
         <span class="date">2024-01-01</span>
         <p>Desc A</p>
       </div>
       <div class="search-result">
-        <a href="/cB">Contract B</a>
+        <a href="/cB" data-ocid="ocds-b">Contract B</a>
         <span class="org">OrgB</span>
         <span class="supplier">SupB</span>
         <time>2024-02-01</time>
@@ -25,6 +25,7 @@ describe('htmlParser', () => {
     expect(tenders[1].title).to.equal('Contract B');
     expect(tenders[0].organisation).to.equal('OrgA');
     expect(tenders[0].supplier).to.equal('SupA');
+    expect(tenders[0].ocid).to.equal('ocds-a');
   });
 
   it('parses Sell2Wales table rows', () => {

--- a/test/scrape.test.js
+++ b/test/scrape.test.js
@@ -32,6 +32,7 @@ describe('scrape.run', () => {
     expect(rows[0]).to.have.property('source');
     expect(rows[0]).to.have.property('scraped_at');
     expect(rows[0]).to.have.property('tags');
+    expect(rows[0]).to.have.property('ocid');
     const ts = await db.getLastScraped();
     expect(ts).to.be.a('string');
     const cust = await db.getOrganisationsByType('customer');


### PR DESCRIPTION
## Summary
- scrape OCID values from tender listings
- deduplicate tenders using OCID when available
- store OCID in the tenders table
- update test fixtures and unit tests
- document OCID deduplication in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667f1fe39c8328a151649bb958beac