### PR TITLE
Add expandable tender row details

### DIFF
--- a/frontend/available.ejs
+++ b/frontend/available.ejs
@@ -65,14 +65,29 @@
       <th>Link</th>
     </tr>
     <% tenders.forEach(t => { %>
-      <tr>
+      <!-- Each result row can be clicked to reveal a hidden detail row -->
+      <tr class="tenderRow" data-id="<%= t.id %>">
         <td><%= t.title %></td>
         <td><%= t.date %></td>
         <td><%= t.description %></td>
         <td><%= t.source %></td>
         <td><%= t.scraped_at %></td>
         <td><%= t.tags %></td>
-        <td><a href="<%= t.link %>">View</a></td>
+        <!-- Open tender links in a new tab so the dashboard stays visible -->
+        <td><a href="<%= t.link %>" target="_blank">View</a></td>
+      </tr>
+      <tr class="detailRow" data-id="<%= t.id %>" style="display:none">
+        <td colspan="7">
+          <table>
+            <tr><th>Title</th><td><%= t.title %></td></tr>
+            <tr><th>Date</th><td><%= t.date %></td></tr>
+            <tr><th>Description</th><td><%= t.description %></td></tr>
+            <tr><th>Source</th><td><%= t.source %></td></tr>
+            <tr><th>Scraped At</th><td><%= t.scraped_at %></td></tr>
+            <tr><th>Tags</th><td><%= t.tags %></td></tr>
+            <tr><th>Link</th><td><a href="<%= t.link %>" target="_blank"><%= t.link %></a></td></tr>
+          </table>
+        </td>
       </tr>
     <% }) %>
   </table>
@@ -191,6 +206,18 @@
     } else {
       alert('Failed to add source');
     }
+  });
+
+  // Allow each tender row to be expanded to show additional details. The
+  // sibling row with class "detailRow" is toggled when the main row is clicked.
+  document.querySelectorAll('table .tenderRow').forEach(row => {
+    const id = row.dataset.id;
+    row.addEventListener('click', e => {
+      // Ignore clicks on links so the user can open them normally.
+      if (e.target.closest('a')) return;
+      const detail = document.querySelector(`.detailRow[data-id="${id}"]`);
+      detail.style.display = detail.style.display === 'none' ? '' : 'none';
+    });
   });
   </script>
   <!-- Enhance tables with search, filter and sort capabilities -->

--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -65,14 +65,28 @@
       <th>Link</th>
     </tr>
     <% tenders.forEach(t => { %>
-      <tr>
+      <tr class="tenderRow" data-id="<%= t.id %>">
         <td><%= t.title %></td>
         <td><%= t.date %></td>
         <td><%= t.description %></td>
         <td><%= t.source %></td>
         <td><%= t.scraped_at %></td>
         <td><%= t.tags %></td>
-        <td><a href="<%= t.link %>">View</a></td>
+        <!-- Open award links in a new tab to keep the list available -->
+        <td><a href="<%= t.link %>" target="_blank">View</a></td>
+      </tr>
+      <tr class="detailRow" data-id="<%= t.id %>" style="display:none">
+        <td colspan="7">
+          <table>
+            <tr><th>Title</th><td><%= t.title %></td></tr>
+            <tr><th>Date</th><td><%= t.date %></td></tr>
+            <tr><th>Description</th><td><%= t.description %></td></tr>
+            <tr><th>Source</th><td><%= t.source %></td></tr>
+            <tr><th>Scraped At</th><td><%= t.scraped_at %></td></tr>
+            <tr><th>Tags</th><td><%= t.tags %></td></tr>
+            <tr><th>Link</th><td><a href="<%= t.link %>" target="_blank"><%= t.link %></a></td></tr>
+          </table>
+        </td>
       </tr>
     <% }) %>
   </table>
@@ -186,6 +200,18 @@
     } else {
       alert('Failed to add source');
     }
+  });
+
+  // Toggle the visibility of the hidden detail row when a tender row is
+  // clicked. Clicking a link should still open it in a new tab so those
+  // events are ignored.
+  document.querySelectorAll('table .tenderRow').forEach(row => {
+    const id = row.dataset.id;
+    row.addEventListener('click', e => {
+      if (e.target.closest('a')) return;
+      const detail = document.querySelector(`.detailRow[data-id="${id}"]`);
+      detail.style.display = detail.style.display === 'none' ? '' : 'none';
+    });
   });
   </script>
   <!-- Enhance tables with search, filter and sort capabilities -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -78,6 +78,22 @@ button:hover {
   background: #f5f5f5;
 }
 
+/* Indicate that rows can be clicked to reveal more information */
+.tenderRow {
+  cursor: pointer;
+}
+
+/* Simple layout for the nested table shown inside detail rows */
+.detailRow table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.detailRow th,
+.detailRow td {
+  border: none;
+  padding: 0.25rem 0.5rem;
+}
+
 /* Small arrow shown next to sortable headers */
 .sort-icon {
   margin-left: 0.25rem;


### PR DESCRIPTION
## Summary
- open tender links in a new tab
- allow clicking on a tender row to show a structured detail row
- style detail rows and mark rows as clickable

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686682d949488328b1fe603aab6e5062