### PR TITLE
Add per-source details to stats page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ the same opportunity even if the URL changes between runs.
 
 ## Statistics
 
-The `/stats` page displays when the scraper last completed successfully. This
-helps you confirm that automated cron jobs are running as expected.
+The `/stats` page lists detailed information about each configured source. It
+shows when every site was last scraped, how many tenders were inserted during
+the most recent run and the running total stored in the database. This helps
+identify sources that consistently produce zero results so potential issues can
+be debugged quickly.
 
 ## Logs
 

--- a/frontend/stats.ejs
+++ b/frontend/stats.ejs
@@ -11,5 +11,23 @@
     <!-- Display the stored timestamp or a placeholder when no scrape has been run yet -->
     Last scraped: <%= lastScraped ? lastScraped : 'Never' %>
   </p>
+  <!-- Detailed table showing statistics for every configured source. This helps
+       diagnose problems when certain sites consistently produce zero tenders. -->
+  <table>
+    <tr>
+      <th>Source</th>
+      <th>Last Scraped</th>
+      <th>Tenders Last Scrape</th>
+      <th>Total Tenders</th>
+    </tr>
+    <% Object.keys(sources).forEach(key => { %>
+      <tr>
+        <td><%= sources[key].label %></td>
+        <td><%= sourceStats[key] ? sourceStats[key].last_scraped || 'Never' : 'Never' %></td>
+        <td><%= sourceStats[key] ? sourceStats[key].last_added : 0 %></td>
+        <td><%= sourceStats[key] ? sourceStats[key].total : 0 %></td>
+      </tr>
+    <% }) %>
+  </table>
 </body>
 </html>

--- a/server/index.js
+++ b/server/index.js
@@ -107,7 +107,21 @@ app.get('/awarded', async (req, res) => {
 // so users know how fresh the displayed data is.
 app.get('/stats', async (req, res) => {
   const lastScraped = await db.getLastScraped();
-  res.render('stats', { lastScraped });
+  // Retrieve per-source statistics so the UI can show detailed
+  // information for debugging purposes.
+  const statsRows = await db.getSourceStats();
+  // Convert the list of rows into an object keyed by source for easier lookups
+  // in the template.
+  const stats = {};
+  for (const row of statsRows) {
+    stats[row.key] = row;
+  }
+  res.render('stats', {
+    lastScraped,
+    // Provide the list of sources so labels can be shown alongside stats.
+    sources: config.sources,
+    sourceStats: stats
+  });
 });
 
 // Lists of organisations scraped from tender sources


### PR DESCRIPTION
## Summary
- fetch per-source stats in `/stats` route
- display last scrape, per-source counts in `stats.ejs`
- document new stats page in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668525557c8328bbaa0b437a6bdd83