### PR TITLE
Add dashboard and tabbed UI

### DIFF
--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -6,8 +6,7 @@
 </head>
 <body>
   <h1>Admin</h1>
-  <a href="/opportunities">Back to dashboard</a> |
-  <a href="/logout">Logout</a>
+  <%- include('partials/nav', { page: 'admin', user: user }) %>
 
   <!-- Form to trigger a full database reset -->
   <h2>Database</h2>

--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -6,16 +6,7 @@
 </head>
 <body>
   <h1>Awarded Contracts</h1>
-  <% if (user) { %>
-    <a href="/admin">Admin</a> |
-    <a href="/logout">Logout</a> |
-  <% } else { %>
-    <a href="/login">Login</a> |
-  <% } %>
-  <a href="/opportunities">Opportunities</a> |
-  <a href="/scraper">Scraper</a> |
-  <a href="/crm">CRM</a> |
-  <a href="/stats">Stats</a>
+  <%- include('partials/nav', { page: 'awarded', user: user }) %>
   <table>
     <tr>
       <th>Title</th>

--- a/frontend/crm.ejs
+++ b/frontend/crm.ejs
@@ -6,10 +6,7 @@
 </head>
 <body>
   <h1>CRM</h1>
-  <a href="/opportunities">Opportunities</a> |
-  <a href="/awarded">Awarded Contracts</a> |
-  <a href="/scraper">Scraper</a> |
-  <a href="/stats">Stats</a>
+  <%- include('partials/nav', { page: 'crm', user: user }) %>
 
   <h2>Funding Bodies</h2>
   <table>

--- a/frontend/customers.ejs
+++ b/frontend/customers.ejs
@@ -6,10 +6,7 @@
 </head>
 <body>
   <h1>Customers</h1>
-  <a href="/opportunities">Opportunities</a> |
-  <a href="/awarded">Awarded Contracts</a> |
-  <a href="/scraper">Scraper</a> |
-  <a href="/stats">Stats</a>
+  <%- include('partials/nav', { page: 'crm', user: user }) %>
   <table>
     <tr><th>Name</th></tr>
     <% organisations.forEach(o => { %>

--- a/frontend/dashboard.ejs
+++ b/frontend/dashboard.ejs
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <%- include('partials/nav', { page: 'dashboard', user: user }) %>
+  <button id="scrapeAll">Scrape All Now</button>
+  <div id="feed"></div>
+  <h2>Source Status</h2>
+  <ul>
+    <% Object.keys(sources).forEach(key => { %>
+      <li id="status-<%= key %>">
+        <span class="status-light <%= sourceStatus[key] === 'ok' ? 'ok' : sourceStatus[key] === 'error' ? 'error' : '' %>"></span>
+        <%= sources[key].label %>
+      </li>
+    <% }) %>
+  </ul>
+<script>
+// Display log messages from the server in real time
+const feed = document.getElementById('feed');
+const logStream = new EventSource('/logs');
+logStream.onmessage = e => {
+  const data = JSON.parse(e.data);
+  const div = document.createElement('div');
+  div.textContent = `[${data.level}] ${data.message}`;
+  feed.appendChild(div);
+  feed.scrollTop = feed.scrollHeight;
+};
+
+// Trigger a scrape of all sources using SSE progress reporting
+function runScrape(){
+  const es = new EventSource('/scrape-all-stream');
+  es.onmessage = evt => {
+    const data = JSON.parse(evt.data);
+    if(data.done){
+      es.close();
+    } else if(data.source){
+      const li = document.getElementById('status-'+data.source);
+      if(li){
+        const light = li.querySelector('.status-light');
+        if(data.error){
+          light.classList.add('error');
+        } else {
+          light.classList.add('ok');
+        }
+      }
+    }
+  };
+}
+
+document.getElementById('scrapeAll').addEventListener('click', runScrape);
+</script>
+</body>
+</html>

--- a/frontend/login.ejs
+++ b/frontend/login.ejs
@@ -6,6 +6,7 @@
 </head>
 <body>
   <h1>Login</h1>
+  <%- include('partials/nav', { page: 'login', user: user }) %>
   <% if (typeof error !== 'undefined') { %>
     <p style="color:red"><%= error %></p>
   <% } %>

--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -6,16 +6,7 @@
 </head>
 <body>
   <h1>Opportunities</h1>
-  <% if (user) { %>
-    <a href="/admin">Admin</a> |
-    <a href="/logout">Logout</a> |
-  <% } else { %>
-    <a href="/login">Login</a> |
-  <% } %>
-  <a href="/scraper">Scraper</a> |
-  <a href="/awarded">Awarded Contracts</a> |
-  <a href="/crm">CRM</a> |
-  <a href="/stats">Stats</a>
+  <%- include('partials/nav', { page: 'opportunities', user: user }) %>
   <table>
     <tr>
       <th>Title</th>

--- a/frontend/partials/nav.ejs
+++ b/frontend/partials/nav.ejs
@@ -1,0 +1,14 @@
+<ul class="tabs">
+  <li class="<%= page === 'dashboard' ? 'active' : '' %>"><a href="/dashboard">Dashboard</a></li>
+  <li class="<%= page === 'opportunities' ? 'active' : '' %>"><a href="/opportunities">Opportunities</a></li>
+  <li class="<%= page === 'awarded' ? 'active' : '' %>"><a href="/awarded">Awarded</a></li>
+  <li class="<%= page === 'scraper' ? 'active' : '' %>"><a href="/scraper">Scraper</a></li>
+  <li class="<%= page === 'crm' ? 'active' : '' %>"><a href="/crm">CRM</a></li>
+  <li class="<%= page === 'stats' ? 'active' : '' %>"><a href="/stats">Stats</a></li>
+  <% if (user) { %>
+    <li class="right"><a href="/admin">Admin</a></li>
+    <li class="right"><a href="/logout">Logout</a></li>
+  <% } else { %>
+    <li class="right"><a href="/login">Login</a></li>
+  <% } %>
+</ul>

--- a/frontend/register.ejs
+++ b/frontend/register.ejs
@@ -6,6 +6,7 @@
 </head>
 <body>
   <h1>Register</h1>
+  <%- include('partials/nav', { page: 'login', user: user }) %>
   <% if (typeof error !== 'undefined') { %>
     <p style="color:red"><%= error %></p>
   <% } %>

--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -6,10 +6,7 @@
 </head>
 <body>
   <h1>Scraper</h1>
-  <a href="/opportunities">Opportunities</a> |
-  <a href="/awarded">Awarded Contracts</a> |
-  <a href="/crm">CRM</a> |
-  <a href="/stats">Stats</a>
+  <%- include('partials/nav', { page: 'scraper', user: user }) %>
   <table id="sourceTable">
     <tr>
       <th>Key</th>

--- a/frontend/stats.ejs
+++ b/frontend/stats.ejs
@@ -6,7 +6,7 @@
 </head>
 <body>
   <h1>Scrape Statistics</h1>
-  <a href="/opportunities">Back to dashboard</a>
+  <%- include('partials/nav', { page: 'stats', user: user }) %>
   <p>
     <!-- Display the stored timestamp or a placeholder when no scrape has been run yet -->
     Last scraped: <%= lastScraped ? lastScraped : 'Never' %>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -99,3 +99,15 @@ button:hover {
   margin-left: 0.25rem;
   font-size: 0.8em;
 }
+
+/* Tabbed navigation bar */
+.tabs { list-style:none; margin:0 0 1rem 0; padding:0; display:flex; border-bottom:1px solid #ccc; }
+.tabs li { margin:0; }
+.tabs li.right { margin-left:auto; }
+.tabs a { display:block; padding:0.5rem 1rem; text-decoration:none; border:1px solid #ccc; border-bottom:none; background:#eee; }
+.tabs li.active a { background:#fff; font-weight:bold; }
+
+/* Status indicator circles used on the dashboard */
+.status-light { width:12px; height:12px; border-radius:50%; background:#ccc; display:inline-block; margin-right:0.5rem; }
+.status-light.ok { background:#0a0; }
+.status-light.error { background:#d00; }

--- a/frontend/suppliers.ejs
+++ b/frontend/suppliers.ejs
@@ -6,10 +6,7 @@
 </head>
 <body>
   <h1>Suppliers</h1>
-  <a href="/opportunities">Opportunities</a> |
-  <a href="/awarded">Awarded Contracts</a> |
-  <a href="/scraper">Scraper</a> |
-  <a href="/stats">Stats</a>
+  <%- include('partials/nav', { page: 'crm', user: user }) %>
   <table>
     <tr><th>Name</th></tr>
     <% organisations.forEach(o => { %>


### PR DESCRIPTION
## Summary
- add a new dashboard page that streams logs and allows running `scrape-all`
- create a shared tabbed nav bar and include on all pages
- style navigation tabs and status indicators
- expose log events through SSE and provide `/logs` endpoint
- add `/scrape-all-stream` SSE route
- update server routes to pass active page info

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866933523388328bbfcc9e08581c6f8