### PR TITLE
Add diagnostics and dashboard summary

### DIFF
--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -17,6 +17,9 @@
       <th>Tags</th>
       <th>Link</th>
     </tr>
+    <% if (tenders.length === 0) { %>
+      <tr><td colspan="7">No awarded contracts found. Run the awards scraper.</td></tr>
+    <% } %>
     <% tenders.forEach(t => { %>
       <tr class="tenderRow" data-id="<%= t.id %>">
         <td><%= t.title %></td>

--- a/frontend/crm.ejs
+++ b/frontend/crm.ejs
@@ -11,6 +11,9 @@
   <h2>Funding Bodies</h2>
   <table>
     <tr><th>Name</th></tr>
+    <% if (customers.length === 0) { %>
+      <tr><td>No funding bodies found.</td></tr>
+    <% } %>
     <% customers.forEach(c => { %>
       <tr><td><%= c.name %></td></tr>
     <% }) %>
@@ -19,6 +22,9 @@
   <h2>Suppliers</h2>
   <table>
     <tr><th>Name</th></tr>
+    <% if (suppliers.length === 0) { %>
+      <tr><td>No suppliers found.</td></tr>
+    <% } %>
     <% suppliers.forEach(s => { %>
       <tr><td><%= s.name %></td></tr>
     <% }) %>

--- a/frontend/dashboard.ejs
+++ b/frontend/dashboard.ejs
@@ -7,6 +7,14 @@
 <body>
   <h1>Dashboard</h1>
   <%- include('partials/nav', { page: 'dashboard', user: user }) %>
+  <div id="summary">
+    <ul>
+      <li>Opportunities: <%= counts.tenders %></li>
+      <li>Awarded contracts: <%= counts.awards %></li>
+      <li>Funding bodies: <%= counts.customers %></li>
+      <li>Suppliers: <%= counts.suppliers %></li>
+    </ul>
+  </div>
   <button id="scrapeAll">Scrape All Now</button>
   <div id="feed"></div>
   <h2>Source Status</h2>

--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -17,6 +17,9 @@
       <th>Tags</th>
       <th>Link</th>
     </tr>
+    <% if (tenders.length === 0) { %>
+      <tr><td colspan="7">No opportunities found. Run the scraper to load data.</td></tr>
+    <% } %>
     <% tenders.forEach(t => { %>
       <!-- Each result row can be clicked to reveal a hidden detail row -->
       <tr class="tenderRow" data-id="<%= t.id %>">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -111,3 +111,7 @@ button:hover {
 .status-light { width:12px; height:12px; border-radius:50%; background:#ccc; display:inline-block; margin-right:0.5rem; }
 .status-light.ok { background:#0a0; }
 .status-light.error { background:#d00; }
+
+/* Summary list on the dashboard */
+#summary ul { list-style:none; padding-left:0; margin:0 0 1rem 0; }
+#summary li { display:inline-block; margin-right:1rem; }

--- a/server/db.js
+++ b/server/db.js
@@ -177,6 +177,21 @@ module.exports = {
   },
 
   /**
+   * Count how many tenders are stored in the database. This is used by the
+   * dashboard to summarise how much data has been scraped so far.
+   *
+   * @returns {Promise<number>} resolves with the number of tender rows
+   */
+  getTenderCount: () => {
+    return new Promise((resolve, reject) => {
+      db.get('SELECT COUNT(*) AS c FROM tenders', (err, row) => {
+        if (err) return reject(err);
+        resolve(row.c);
+      });
+    });
+  },
+
+  /**
    * Insert an awarded contract if it does not already exist. The parameters
    * mirror insertTender so the scraper logic can be reused for awarded data.
    */
@@ -203,6 +218,21 @@ module.exports = {
       db.all("SELECT * FROM awards ORDER BY date DESC", [], (err, rows) => {
         if (err) return reject(err);
         resolve(rows);
+      });
+    });
+  },
+
+  /**
+   * Count the number of awarded contracts stored. Displayed on the dashboard
+   * so users can see if the award scraper has captured any data yet.
+   *
+   * @returns {Promise<number>} resolves with the number of award rows
+   */
+  getAwardCount: () => {
+    return new Promise((resolve, reject) => {
+      db.get('SELECT COUNT(*) AS c FROM awards', (err, row) => {
+        if (err) return reject(err);
+        resolve(row.c);
       });
     });
   },
@@ -435,6 +465,26 @@ module.exports = {
         (err, rows) => {
           if (err) return reject(err);
           resolve(rows);
+        }
+      );
+    });
+  },
+
+  /**
+   * Count organisations of a given type. Useful for displaying CRM statistics
+   * on the dashboard.
+   *
+   * @param {string} type - Organisation type to count
+   * @returns {Promise<number>} resolves with the number of matching rows
+   */
+  getOrganisationCount: type => {
+    return new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COUNT(*) AS c FROM organisations WHERE type = ?',
+        [type],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row.c);
         }
       );
     });

--- a/server/index.js
+++ b/server/index.js
@@ -105,9 +105,22 @@ app.get('/dashboard', async (req, res) => {
   for (const row of statsRows) {
     stats[row.key] = row;
   }
+  // Fetch basic counts so the dashboard can summarise how much data exists.
+  const [tenderCount, awardCount, customerCount, supplierCount] = await Promise.all([
+    db.getTenderCount(),
+    db.getAwardCount(),
+    db.getOrganisationCount('customer'),
+    db.getOrganisationCount('supplier')
+  ]);
   res.render('dashboard', {
     sources: config.sources,
     sourceStatus,
+    counts: {
+      tenders: tenderCount,
+      awards: awardCount,
+      customers: customerCount,
+      suppliers: supplierCount
+    },
     page: 'dashboard'
   });
 });


### PR DESCRIPTION
## Summary
- show counts on the dashboard
- display messages when opportunities/awards/CRM tables are empty
- expose DB helper methods for counts

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866982747d883288137c558a7e68d83