### PR TITLE
Add diagnostics and data counts

### DIFF
--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -42,6 +42,9 @@
         </td>
       </tr>
     <% }) %>
+    <% if (tenders.length === 0) { %>
+      <tr><td colspan="7">No awarded contracts found. Scrape an award source to populate this list.</td></tr>
+    <% } %>
   </table>
   <script>
   // Enable clicking a row to reveal the nested detail table.

--- a/frontend/crm.ejs
+++ b/frontend/crm.ejs
@@ -14,6 +14,9 @@
     <% customers.forEach(c => { %>
       <tr><td><%= c.name %></td></tr>
     <% }) %>
+    <% if (customers.length === 0) { %>
+      <tr><td>No customers found.</td></tr>
+    <% } %>
   </table>
 
   <h2>Suppliers</h2>
@@ -22,6 +25,9 @@
     <% suppliers.forEach(s => { %>
       <tr><td><%= s.name %></td></tr>
     <% }) %>
+    <% if (suppliers.length === 0) { %>
+      <tr><td>No suppliers found.</td></tr>
+    <% } %>
   </table>
 
   <h2>People</h2>

--- a/frontend/customers.ejs
+++ b/frontend/customers.ejs
@@ -12,6 +12,9 @@
     <% organisations.forEach(o => { %>
       <tr><td><%= o.name %></td></tr>
     <% }) %>
+    <% if (organisations.length === 0) { %>
+      <tr><td>No customers found.</td></tr>
+    <% } %>
   </table>
   <script src="/table-tools.js"></script>
 </body>

--- a/frontend/dashboard.ejs
+++ b/frontend/dashboard.ejs
@@ -9,6 +9,14 @@
   <%- include('partials/nav', { page: 'dashboard', user: user }) %>
   <button id="scrapeAll">Scrape All Now</button>
   <div id="feed"></div>
+  <!-- Quick overview showing how much data has been scraped so far -->
+  <h2>Summary</h2>
+  <ul>
+    <li>Open tenders: <%= counts.tenders %></li>
+    <li>Awarded contracts: <%= counts.awards %></li>
+    <li>Customers: <%= counts.customers %></li>
+    <li>Suppliers: <%= counts.suppliers %></li>
+  </ul>
   <h2>Source Status</h2>
   <ul>
     <% Object.keys(sources).forEach(key => { %>

--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -43,6 +43,9 @@
         </td>
       </tr>
     <% }) %>
+    <% if (tenders.length === 0) { %>
+      <tr><td colspan="7">No opportunities found. Try running the scraper.</td></tr>
+    <% } %>
   </table>
   <script>
   // Toggle the detail row when a tender row is clicked so users can view extra

--- a/frontend/suppliers.ejs
+++ b/frontend/suppliers.ejs
@@ -12,6 +12,9 @@
     <% organisations.forEach(o => { %>
       <tr><td><%= o.name %></td></tr>
     <% }) %>
+    <% if (organisations.length === 0) { %>
+      <tr><td>No suppliers found.</td></tr>
+    <% } %>
   </table>
   <script src="/table-tools.js"></script>
 </body>

--- a/server/db.js
+++ b/server/db.js
@@ -441,6 +441,53 @@ module.exports = {
   },
 
   /**
+   * Count how many tenders have been stored.
+   *
+   * @returns {Promise<number>} total number of tender rows
+   */
+  getTenderCount: () => {
+    return new Promise((resolve, reject) => {
+      db.get('SELECT COUNT(*) AS c FROM tenders', (err, row) => {
+        if (err) return reject(err);
+        resolve(row.c);
+      });
+    });
+  },
+
+  /**
+   * Count stored awarded contracts.
+   *
+   * @returns {Promise<number>} total number of award rows
+   */
+  getAwardCount: () => {
+    return new Promise((resolve, reject) => {
+      db.get('SELECT COUNT(*) AS c FROM awards', (err, row) => {
+        if (err) return reject(err);
+        resolve(row.c);
+      });
+    });
+  },
+
+  /**
+   * Count organisations of a particular type such as 'customer' or 'supplier'.
+   *
+   * @param {string} type - Organisation type to count
+   * @returns {Promise<number>} number of organisations
+   */
+  getOrganisationCount: type => {
+    return new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COUNT(*) AS c FROM organisations WHERE type = ?',
+        [type],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row.c);
+        }
+      );
+    });
+  },
+
+  /**
    * Update an existing scraping source definition. The key cannot be changed
    * as it forms the primary identifier used throughout the application.
    *

--- a/server/index.js
+++ b/server/index.js
@@ -105,9 +105,20 @@ app.get('/dashboard', async (req, res) => {
   for (const row of statsRows) {
     stats[row.key] = row;
   }
+  // Gather basic totals so the dashboard can report how many records exist.
+  const tenderCount = await db.getTenderCount();
+  const awardCount = await db.getAwardCount();
+  const customerCount = await db.getOrganisationCount('customer');
+  const supplierCount = await db.getOrganisationCount('supplier');
   res.render('dashboard', {
     sources: config.sources,
     sourceStatus,
+    counts: {
+      tenders: tenderCount,
+      awards: awardCount,
+      customers: customerCount,
+      suppliers: supplierCount
+    },
     page: 'dashboard'
   });
 });

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -136,4 +136,18 @@ describe('Database helpers', () => {
     expect(row.value).to.equal('100');
     expect(row.location).to.equal('X');
   });
+
+  it('count helpers return the number of stored rows', async () => {
+    const tenderCount = await db.getTenderCount();
+    const awardCount = await db.getAwardCount();
+    const custCount = await db.getOrganisationCount('customer');
+    const suppCount = await db.getOrganisationCount('supplier');
+    expect(tenderCount).to.be.a('number');
+    expect(awardCount).to.be.a('number');
+    expect(custCount).to.be.a('number');
+    expect(suppCount).to.be.a('number');
+    // There should be at least one tender and award from previous tests
+    expect(tenderCount).to.be.greaterThan(0);
+    expect(awardCount).to.be.greaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- improve DB helper coverage with new count utilities
- show quick stats on dashboard to confirm data was scraped
- display a helpful message when opportunity, award or CRM tables are empty

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6866993984388328b139d15d24bee272