### PR TITLE
Add tender cleanup tools

### DIFF
--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -7,6 +7,14 @@
 <body>
   <h1>Scraper</h1>
   <%- include('partials/nav', { page: 'scraper', user: user }) %>
+  <h2>Database Tools</h2>
+  <form id="deleteAllForm">
+    <button type="submit">Delete All Records</button>
+  </form>
+  <form id="deleteBeforeForm">
+    <input type="date" id="deleteDate">
+    <button type="submit">Delete Records Before Date</button>
+  </form>
   <table id="sourceTable">
     <tr>
       <th>Key</th>
@@ -109,6 +117,36 @@ document.querySelectorAll('.detailRow').forEach(row => {
       alert('Failed to update source');
     }
   });
+});
+
+// Handle deletion of all tenders via admin endpoint.
+document.getElementById('deleteAllForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  if (!confirm('Delete all tender records?')) return;
+  const res = await fetch('/admin/delete-all', { method: 'POST' });
+  if (res.ok) {
+    alert('All tenders removed');
+  } else {
+    alert('Failed to delete records');
+  }
+});
+
+// Delete tenders older than the user supplied date.
+document.getElementById('deleteBeforeForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const date = document.getElementById('deleteDate').value;
+  if (!date) return alert('Select a date first');
+  if (!confirm(`Delete tenders before ${date}?`)) return;
+  const res = await fetch('/admin/delete-before', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ date })
+  });
+  if (res.ok) {
+    alert('Old tenders removed');
+  } else {
+    alert('Failed to delete records');
+  }
 });
 </script>
 <script src="/table-tools.js"></script>

--- a/server/db.js
+++ b/server/db.js
@@ -488,6 +488,36 @@ module.exports = {
   },
 
   /**
+   * Delete all tenders from the database. Used by admin tools to clear
+   * stored data without dropping and recreating the entire schema.
+   *
+   * @returns {Promise<void>} resolves when all rows are removed
+   */
+  deleteAllTenders: () => {
+    return new Promise((resolve, reject) => {
+      db.run('DELETE FROM tenders', err => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  },
+
+  /**
+   * Delete tenders older than a specific published date.
+   *
+   * @param {string} date - ISO date string, rows with a date prior to this are removed
+   * @returns {Promise<void>} resolves when deletion completes
+   */
+  deleteTendersBefore: date => {
+    return new Promise((resolve, reject) => {
+      db.run('DELETE FROM tenders WHERE date < ?', [date], err => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  },
+
+  /**
    * Update an existing scraping source definition. The key cannot be changed
    * as it forms the primary identifier used throughout the application.
    *

--- a/server/index.js
+++ b/server/index.js
@@ -500,6 +500,31 @@ app.post('/admin/reset-db', requireAuth, async (req, res) => {
   }
 });
 
+// Remove every tender from the database. Authentication is required so only
+// authorised users can perform destructive actions.
+app.post('/admin/delete-all', requireAuth, async (req, res) => {
+  try {
+    await db.deleteAllTenders();
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('Failed to delete all tenders:', err);
+    res.status(500).json({ error: 'Failed to delete data' });
+  }
+});
+
+// Delete tenders older than the supplied date.
+app.post('/admin/delete-before', requireAuth, async (req, res) => {
+  const date = req.body && req.body.date;
+  if (!date) return res.status(400).json({ error: 'Missing date' });
+  try {
+    await db.deleteTendersBefore(date);
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('Failed to delete old tenders:', err);
+    res.status(500).json({ error: 'Failed to delete data' });
+  }
+});
+
 // POST /admin/cron - Update the cron schedule at runtime. The existing job is
 // stopped and a new one is created using the supplied expression.
 app.post('/admin/cron', requireAuth, async (req, res) => {

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -150,4 +150,20 @@ describe('Database helpers', () => {
     expect(tenderCount).to.be.greaterThan(0);
     expect(awardCount).to.be.greaterThan(0);
   });
+
+  it('deleteAllTenders removes everything', async () => {
+    await db.deleteAllTenders();
+    const count = await db.getTenderCount();
+    expect(count).to.equal(0);
+  });
+
+  it('deleteTendersBefore removes only old rows', async () => {
+    await db.insertTender('new', 'n1', '2024-05-01', 'd', 's', '2024-05-02T00:00:00Z', 't', 'ocds-n');
+    await db.insertTender('old', 'o1', '2023-01-01', 'd', 's', '2023-01-02T00:00:00Z', 't', 'ocds-o');
+    await db.deleteTendersBefore('2024-01-01');
+    const rows = await db.getTenders();
+    const titles = rows.map(r => r.title);
+    expect(titles).to.include('new');
+    expect(titles).to.not.include('old');
+  });
 });


### PR DESCRIPTION
## Summary
- add DB helpers for removing tender rows
- expose deletion APIs from the server
- include tender cleanup options on the scraper page
- test the new DB functions

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669b295d0483288b242ea95888b549