### PR TITLE
Fix table pagination size

### DIFF
--- a/frontend/table-tools.js
+++ b/frontend/table-tools.js
@@ -112,8 +112,11 @@ function enhanceTable(table) {
     th.addEventListener('click', () => sortByColumn(idx));
   });
 
-  // Pagination state: how many rows per page and the current page index.
-  const pageSize = 20;
+  // Pagination state: how many rows to show per page and the current page.
+  // Larger tables can slow down the browser when rendered in full, so we
+  // cap the number of visible rows at 100. Adjust pageSize here to change the
+  // default across all tables.
+  const pageSize = 100;
   let currentPage = 0;
   let filteredCount = pairs.length;
 


### PR DESCRIPTION
## Summary
- bump pagination to show 100 rows per page by default

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a195bd748328b98b4c633a587a2a