### PR TITLE
Fix database schema migration and add test

### DIFF
--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+const { expect } = require('chai');
+
+it('adds ocid column if missing', async () => {
+  const file = path.join(__dirname, 'migrate.db');
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+  // Create old schema without ocid
+  const oldDb = new sqlite3.Database(file);
+  await new Promise(res => oldDb.run(`CREATE TABLE tenders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    link TEXT UNIQUE,
+    date TEXT,
+    description TEXT,
+    source TEXT,
+    scraped_at TEXT,
+    tags TEXT
+  )`, res));
+  await new Promise(res => oldDb.close(res));
+
+  // Load db.js which should migrate the schema
+  process.env.DB_FILE = file;
+  delete require.cache[require.resolve('../server/db')];
+  const db = require('../server/db');
+
+  await db.insertTender('t', 'l', '2024-01-01', 'd', 's', '2024-01-02', 'tag', 'ocid-1');
+  const rows = await db.getTenders();
+  expect(rows[0].ocid).to.equal('ocid-1');
+  fs.unlinkSync(file);
+});


### PR DESCRIPTION
## Summary
- ensure `ocid` column exists at startup
- create unique index for ocid to avoid duplicates
- add regression test verifying schema migration

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a99e3c408328a863c76da3320b57