### PR TITLE
Implement server pagination

### DIFF
--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -43,10 +43,20 @@
         </td>
       </tr>
     <% }) %>
-    <% if (tenders.length === 0) { %>
+  <% if (tenders.length === 0) { %>
       <tr><td colspan="7">No opportunities found. Try running the scraper.</td></tr>
-    <% } %>
+  <% } %>
   </table>
+  <div class="server-pagination">
+    <% const totalPages = Math.max(1, Math.ceil(total / 100)); %>
+    <% if (currentPage > 0) { %>
+      <a href="/opportunities?page=<%= currentPage - 1 %>">Prev</a>
+    <% } %>
+    Page <%= currentPage + 1 %> of <%= totalPages %>
+    <% if (currentPage < totalPages - 1) { %>
+      <a href="/opportunities?page=<%= currentPage + 1 %>">Next</a>
+    <% } %>
+  </div>
   <script>
   // Toggle the detail row when a tender row is clicked so users can view extra
   // information without leaving the page.

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -120,3 +120,12 @@ button:hover {
 .pagination button {
   margin: 0 0.25rem;
 }
+
+/* Pagination used for server-side pages mirrors the table controls */
+.server-pagination {
+  margin-top: 0.5rem;
+  text-align: center;
+}
+.server-pagination a {
+  margin: 0 0.25rem;
+}

--- a/server/db.js
+++ b/server/db.js
@@ -194,6 +194,11 @@ module.exports = {
 
   /**
    * Retrieve all stored tenders ordered by published date descending.
+   *
+   * This helper is retained for backwards compatibility in places that
+   * expect all rows at once (primarily tests). New code should prefer
+   * {@link getTendersPage} so large result sets can be fetched in chunks.
+   *
    * @returns {Promise<Array>} resolves with an array of tender rows
    */
   getTenders: () => {
@@ -205,6 +210,29 @@ module.exports = {
           resolve(rows);
         }
       });
+    });
+  },
+
+  /**
+   * Retrieve a single page of tenders ordered by published date.
+   *
+   * @param {number} limit  Maximum number of rows to return
+   * @param {number} offset Number of rows to skip from the start of the table
+   * @returns {Promise<Array>} resolves with the requested tender rows
+   */
+  getTendersPage: (limit, offset) => {
+    return new Promise((resolve, reject) => {
+      db.all(
+        "SELECT * FROM tenders ORDER BY date DESC LIMIT ? OFFSET ?",
+        [limit, offset],
+        (err, rows) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(rows);
+          }
+        }
+      );
     });
   },
 


### PR DESCRIPTION
## Summary
- fetch opportunities in pages rather than loading all rows
- expose a new `getTendersPage` DB helper
- show prev/next controls for navigating pages
- style server pagination controls

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ae3daae88328be65a6bfc75962ec