### PR TITLE
Fix opportunities table filtering

### DIFF
--- a/frontend/table-tools.js
+++ b/frontend/table-tools.js
@@ -8,13 +8,19 @@
  * @param {HTMLTableElement} table Target table element.
  */
 function enhanceTable(table) {
-  const headers = Array.from(table.querySelectorAll('th'));
+  // Only consider header cells from the first row so nested tables are ignored
+  const headerRow = table.rows[0];
+  if (!headerRow) return;
+  const headers = Array.from(headerRow.cells);
 
   // Build a list of data rows and store references to accompanying detail rows
   // (if present). These pairs are used for filtering, sorting and pagination so
   // detail rows remain attached to their parent record.
   const pairs = [];
-  const allRows = Array.from(table.querySelectorAll('tr')).slice(1); // skip header
+  // Grab only direct child rows after the header. querySelectorAll('tr') would
+  // also return rows from nested tables which corrupts the layout when
+  // filtered or sorted.
+  const allRows = Array.from(table.rows).slice(1); // skip header
   for (let i = 0; i < allRows.length; i++) {
     const main = allRows[i];
     if (main.classList.contains('detailRow')) continue;


### PR DESCRIPTION
## Summary
- keep nested tables untouched in table-tools.js

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bc66a58c83288aef571bccb79e74