### PR TITLE
Fix custom source persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ See the `/help` page for example configurations.
 6. Optionally specify a **parser** name. Use `rss` for RSS feeds or one of the
    custom parsers listed in `server/htmlParser.js`.
 7. Click **Add Source** to save. The source is stored in the database and can be
-   selected immediately.
+   selected immediately. A small JSON file (`sources.json`) is also written so
+   custom sources survive server restarts even if the database is cleared.
 8. Existing sources are shown in a list below the form. Click **Edit** to modify
    details or **Delete** to remove a source altogether.
 
@@ -125,4 +126,6 @@ procurement portals pre-configured so you can start scraping immediately.
 
 Award notices are scraped separately using the same mechanism. Use the **Award
 Sources** form on the Scraper page to register feeds that list awarded
-contracts. Example award sources are shown on the `/help` page.
+contracts. Example award sources are shown on the `/help` page. Like tender
+sources, award feeds are also saved to `sources.json` to ensure they are
+restored after a restart.

--- a/server/sourceStore.js
+++ b/server/sourceStore.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const config = require('./config');
+
+// Path where custom sources are stored. Using a JSON file keeps
+// things simple and avoids additional database schema changes.
+const file = path.join(__dirname, '../sources.json');
+
+/**
+ * Persist the current source configuration to disk.
+ * Both tender and award sources are written so they can be
+ * restored on the next server start.
+ */
+function save() {
+  const data = {
+    sources: config.sources,
+    awardSources: config.awardSources
+  };
+  try {
+    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+  } catch (err) {
+    // Log the failure but don't crash the server.
+    require('./logger').error('Failed to save sources:', err);
+  }
+}
+
+/**
+ * Load previously saved sources from disk if the file exists.
+ * The data is merged into the config object so defaults remain intact.
+ */
+function load() {
+  if (!fs.existsSync(file)) return;
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    const data = JSON.parse(raw);
+    if (data.sources) {
+      for (const [k, v] of Object.entries(data.sources)) {
+        config.sources[k] = v;
+      }
+    }
+    if (data.awardSources) {
+      for (const [k, v] of Object.entries(data.awardSources)) {
+        config.awardSources[k] = v;
+      }
+    }
+  } catch (err) {
+    require('./logger').error('Failed to load sources:', err);
+  }
+}
+
+module.exports = { save, load };


### PR DESCRIPTION
## Summary
- persist custom sources to a sources.json file as well as the DB
- load saved definitions on startup
- document new persistence behaviour

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c00884e8832880135f70d187c7c8