### PR TITLE
Fix server port selection

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -198,8 +198,9 @@ const defaultTagRules = {
 };
 
 module.exports = {
-  // Port the Express server listens on
-  port: process.env.PORT || 3000,
+  // Port the Express server listens on. Environment variables are parsed as
+  // integers so "3001" is treated the same as 3001.
+  port: process.env.PORT ? parseInt(process.env.PORT, 10) : 3000,
   // Network interface to bind the HTTP server to. Using 0.0.0.0 allows access
   // from other machines on the network. The hostname is logged purely for
   // convenience.

--- a/server/index.js
+++ b/server/index.js
@@ -744,7 +744,10 @@ async function startServer() {
     port = chosen;
   }
 
+  // Persist the chosen port so any modules reading the configuration or
+  // environment variable see the correct value.
   config.port = port;
+  process.env.PORT = String(port);
   app.listen(port, config.host, () => {
     // Display a helpful startup message indicating how the server can be
     // reached. When binding to 0.0.0.0 there is no single address clients should


### PR DESCRIPTION
## Summary
- parse `PORT` env var as an integer
- update selected port in `process.env.PORT` so the app listens correctly on alternate ports

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc271a4c8328b77aabd8b331d0c3