### PR TITLE
Fix scraping loop and parser for new markup

### DIFF
--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -12,11 +12,14 @@ const clean = str => str.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
 
 function parseContractsFinder(html) {
   const tenders = [];
-  // Results are contained within elements that include the "search-result" class
-  const blockRe = /<div[^>]*class="[^"]*search-result[^"]*"[^>]*>([\s\S]*?)<\/div>/gi;
+  // Results are contained within elements that include the "search-result" or
+  // "search-result-entry" class. Some pages use <div> wrappers while others use
+  // <li> elements, so capture the tag name and match the corresponding closing
+  // tag to avoid prematurely ending the block when nested elements are present.
+  const blockRe = /<(div|li)[^>]*class="[^"]*(?:search-result(?:-entry)?)[^"]*"[^>]*>([\s\S]*?)<\/\1>/gi;
   let blockMatch;
   while ((blockMatch = blockRe.exec(html))) {
-    const block = blockMatch[1];
+    const block = blockMatch[2];
     const link = /<a[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/i.exec(block);
     // Some templates place the title inside the anchor, others in a sibling h2
     const title = link ? clean(link[2]) : clean(/<h2[^>]*>(.*?)<\/h2>/i.exec(block)?.[1] || '');

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -28,6 +28,20 @@ describe('htmlParser', () => {
     expect(tenders[0].ocid).to.equal('ocds-a');
   });
 
+  it('parses list items with search-result-entry class', () => {
+    const html = `
+      <ul>
+        <li class="search-result-entry">
+          <a href="/cC">Contract C</a>
+          <span class="date">2024-03-03</span>
+          <p>Desc C</p>
+        </li>
+      </ul>`;
+    const tenders = parseTenders(html, 'contractsFinder');
+    expect(tenders).to.have.length(1);
+    expect(tenders[0].title).to.equal('Contract C');
+  });
+
   it('parses Sell2Wales table rows', () => {
     const html = `
       <table>


### PR DESCRIPTION
## Summary
- handle `search-result-entry` list items when parsing Contracts Finder HTML
- stop pagination loop if page has no tenders
- ignore disabled `next` links to avoid infinite loop
- add regression test for new Contracts Finder markup

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_687782a18d5c832889bf613a4440c917