### PR TITLE
Add Raspberry Pi setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,26 @@ This application scrapes new tenders from several procurement portals including 
    node server/index.js
    ```
    If the default port is already in use the server will automatically select
-   the next free port. The UI will be available at `http://<HOST>:<PORT>`. When
-   `HOST` is set to `0.0.0.0` (the default) the server listens on all network
-   interfaces. Use the IP address of the machine in place of `<HOST>` when
-   connecting from another computer.
+  the next free port. The UI will be available at `http://<HOST>:<PORT>`. When
+  `HOST` is set to `0.0.0.0` (the default) the server listens on all network
+  interfaces. Use the IP address of the machine in place of `<HOST>` when
+  connecting from another computer.
+
+### Raspberry Pi quickstart
+
+The repository includes small helper scripts for Raspberry Pi systems. Run the
+setup script once to install Node.js and initialise the database:
+
+```bash
+./scripts/setup-pi.sh
+```
+
+To start the server on a specific port use the `run.sh` helper. Omit the
+argument to use the default port from `server/config.js`:
+
+```bash
+./scripts/run.sh 4000
+```
 
 ## Usage
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# run.sh - convenience wrapper to launch the server.
+# Usage: ./scripts/run.sh [PORT]
+# When a port number is provided it is exported as the PORT
+# environment variable so the Express application listens
+# on that interface.
+
+set -e
+
+# Respect the first argument as the desired port if present.
+if [ -n "$1" ]; then
+  export PORT="$1"
+fi
+
+# Start the Node.js backend.
+node server/index.js

--- a/scripts/setup-pi.sh
+++ b/scripts/setup-pi.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# setup-pi.sh - prepare the project on a Raspberry Pi.
+# This installs Node.js if required, fetches dependencies
+# and initialises the database.
+
+set -e
+
+# Ensure apt package lists are up to date and install Node.js
+# along with the npm package manager.
+sudo apt-get update
+sudo apt-get install -y nodejs npm
+
+# Install Node.js dependencies declared in package.json.
+npm install
+
+# Initialise the SQLite database so the server can start
+# without errors.
+npm run init-db


### PR DESCRIPTION
## Summary
- add `scripts/setup-pi.sh` for apt-based install and DB setup
- add `scripts/run.sh` wrapper so a custom port can be supplied
- document Raspberry Pi quickstart in README

## Testing
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888a97da62083288982171b8f2cc07e