### PR TITLE
Update Pi setup script for port arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,13 @@ This application scrapes new tenders from several procurement portals including 
 
 ### Raspberry Pi quickstart
 
-The repository includes small helper scripts for Raspberry Pi systems. Run the setup script once to install Node.js and initialise the database. The script is now named `rpi_bidfinder.sh`. Pass the `-p` flag to install only production dependencies:
+The repository includes small helper scripts for Raspberry Pi systems. Run the
+setup script once to install Node.js, initialise the database and optionally
+start the server. Pass the `-p` flag to install only production dependencies and
+provide a port number to immediately launch the application:
 
 ```bash
-./scripts/rpi_bidfinder.sh -p
-```
-
-To start the server on a specific port use the `run.sh` helper. Omit the
-argument to use the default port from `server/config.js`:
-
-```bash
-./scripts/run.sh 4000
+./scripts/rpi_bidfinder.sh -p 4000
 ```
 
 ## Usage

--- a/scripts/rpi_bidfinder.sh
+++ b/scripts/rpi_bidfinder.sh
@@ -1,17 +1,30 @@
 #!/bin/bash
 
 # rpi_bidfinder.sh - prepare the project on a Raspberry Pi.
-# Installs Node.js, fetches dependencies and initialises the database.
-# Use the -p or --production flag to skip dev dependencies.
-# Usage: ./scripts/rpi_bidfinder.sh [-p|--production]
+# Installs Node.js, fetches dependencies, initialises the database and can
+# optionally launch the server. Use the -p or --production flag to skip dev
+# dependencies and supply a port number to start the server immediately.
+# Usage: ./scripts/rpi_bidfinder.sh [-p|--production] [PORT]
 
 set -e
 
-# Parse command line options for production mode
+# Parse command line options for production mode and optional port number. The
+# port argument can be provided in any position as long as it is not preceded
+# by -p or --production.
 PROD=0
-if [[ "$1" == "-p" || "$1" == "--production" ]]; then
-  PROD=1 # toggle to install only production dependencies
-fi
+PORT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--production)
+      PROD=1 # toggle to install only production dependencies
+      shift
+      ;;
+    *)
+      PORT="$1" # treat any other argument as the desired port
+      shift
+      ;;
+  esac
+done
 
 # Ensure system packages are up to date and install Node.js and npm
 sudo apt-get update
@@ -26,4 +39,10 @@ fi
 
 # Initialise the SQLite database so the server can start without errors
 npm run init-db # create the SQLite database
+
+# Launch the application when a port number is supplied. The run.sh helper
+# exports PORT before starting the Node.js server.
+if [[ -n "$PORT" ]]; then
+  ./scripts/run.sh "$PORT"
+fi
 


### PR DESCRIPTION
## Summary
- expand `rpi_bidfinder.sh` to accept a port argument
- launch the app from the script when a port is provided
- document the new usage in the README

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6888c5208d308328801e1eeed7c0fa69