### PR TITLE
Modernise UI and consolidate table scripts

### DIFF
--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -54,13 +54,13 @@
   <table id="sourceTable">
     <tr><th>Key</th><th>Label</th><th>URL</th><th>Base</th></tr>
     <% Object.keys(sources).forEach(key => { %>
-      <tr class="sourceRow" data-key="<%= key %>">
+      <tr class="sourceRow toggle-row" data-key="<%= key %>">
         <td><%= key %></td>
         <td><%= sources[key].label %></td>
         <td><%= sources[key].url %></td>
         <td><%= sources[key].base %></td>
       </tr>
-      <tr class="detailRow" data-key="<%= key %>" style="display:none">
+      <tr class="detailRow" data-key="<%= key %>">
         <td colspan="4">
           Last scraped: <%= sourceStats[key] ? sourceStats[key].last_scraped || 'Never' : 'Never' %><br>
           Tenders last scrape: <%= sourceStats[key] ? sourceStats[key].last_added : 0 %><br>
@@ -87,13 +87,13 @@
   <table id="awardSourceTable">
     <tr><th>Key</th><th>Label</th><th>URL</th><th>Base</th></tr>
     <% Object.keys(awardSources).forEach(key => { %>
-      <tr class="awardSourceRow" data-key="<%= key %>">
+      <tr class="awardSourceRow toggle-row" data-key="<%= key %>">
         <td><%= key %></td>
         <td><%= awardSources[key].label %></td>
         <td><%= awardSources[key].url %></td>
         <td><%= awardSources[key].base %></td>
       </tr>
-      <tr class="awardDetailRow" data-key="<%= key %>" style="display:none">
+      <tr class="awardDetailRow" data-key="<%= key %>">
         <td colspan="4">
           Last scraped: <%= sourceStats[key] ? sourceStats[key].last_scraped || 'Never' : 'Never' %><br>
           Contracts last scrape: <%= sourceStats[key] ? sourceStats[key].last_added : 0 %><br>
@@ -187,10 +187,6 @@ document.getElementById('addSourceForm').addEventListener('submit', async e => {
 // Hook up edit and delete buttons for each listed source
 document.querySelectorAll('#sourceTable .sourceRow').forEach(row => {
   const key = row.dataset.key;
-  row.addEventListener('click', () => {
-    const detail = document.querySelector(`.detailRow[data-key="${key}"]`);
-    detail.style.display = detail.style.display === 'none' ? '' : 'none';
-  });
   const detail = document.querySelector(`.detailRow[data-key="${key}"]`);
   detail.querySelector('.editBtn').addEventListener('click', () => {
     const s = sourceData[key];
@@ -241,10 +237,6 @@ document.getElementById('addAwardSourceForm').addEventListener('submit', async e
 // Edit/delete handlers for award sources
 document.querySelectorAll('#awardSourceTable .awardSourceRow').forEach(row => {
   const key = row.dataset.key;
-  row.addEventListener('click', () => {
-    const detail = document.querySelector(`.awardDetailRow[data-key="${key}"]`);
-    detail.style.display = detail.style.display === 'none' ? '' : 'none';
-  });
   const detail = document.querySelector(`.awardDetailRow[data-key="${key}"]`);
   detail.querySelector('.editBtn').addEventListener('click', () => {
     const s = awardSourceData[key];

--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -18,7 +18,7 @@
       <th>Link</th>
     </tr>
     <% tenders.forEach(t => { %>
-      <tr class="tenderRow" data-id="<%= t.id %>">
+      <tr class="tenderRow toggle-row" data-id="<%= t.id %>">
         <td><%= t.title %></td>
         <td><%= t.date %></td>
         <td><%= t.description %></td>
@@ -28,7 +28,7 @@
         <!-- Open award links in a new tab to keep the list available -->
         <td><a href="<%= t.link %>" target="_blank">View</a></td>
       </tr>
-      <tr class="detailRow" data-id="<%= t.id %>" style="display:none">
+      <tr class="detailRow" data-id="<%= t.id %>">
         <td colspan="7">
           <table>
             <tr><th>Title</th><td><%= t.title %></td></tr>
@@ -46,17 +46,7 @@
       <tr><td colspan="7">No awarded contracts found. Scrape an award source to populate this list.</td></tr>
     <% } %>
   </table>
-  <script>
-  // Enable clicking a row to reveal the nested detail table.
-  document.querySelectorAll('table .tenderRow').forEach(row => {
-    const id = row.dataset.id;
-    row.addEventListener('click', e => {
-      if (e.target.closest('a')) return;
-      const detail = document.querySelector(`.detailRow[data-id="${id}"]`);
-      detail.style.display = detail.style.display === 'none' ? '' : 'none';
-    });
-  });
-  </script>
+  <!-- table-tools.js handles row detail toggling and table utilities -->
   <script src="/table-tools.js"></script>
 </body>
 </html>

--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -19,7 +19,7 @@
     </tr>
     <% tenders.forEach(t => { %>
       <!-- Each result row can be clicked to reveal a hidden detail row -->
-      <tr class="tenderRow" data-id="<%= t.id %>">
+      <tr class="tenderRow toggle-row" data-id="<%= t.id %>">
         <td><%= t.title %></td>
         <td><%= t.date %></td>
         <td><%= t.description %></td>
@@ -29,7 +29,7 @@
         <!-- Open tender links in a new tab so the dashboard stays visible -->
         <td><a href="<%= t.link %>" target="_blank">View</a></td>
       </tr>
-      <tr class="detailRow" data-id="<%= t.id %>" style="display:none">
+      <tr class="detailRow" data-id="<%= t.id %>">
         <td colspan="7">
           <table>
             <tr><th>Title</th><td><%= t.title %></td></tr>
@@ -57,18 +57,8 @@
       <a href="/opportunities?page=<%= currentPage + 1 %>">Next</a>
     <% } %>
   </div>
-  <script>
-  // Toggle the detail row when a tender row is clicked so users can view extra
-  // information without leaving the page.
-  document.querySelectorAll('table .tenderRow').forEach(row => {
-    const id = row.dataset.id;
-    row.addEventListener('click', e => {
-      if (e.target.closest('a')) return;
-      const detail = document.querySelector(`.detailRow[data-id="${id}"]`);
-      detail.style.display = detail.style.display === 'none' ? '' : 'none';
-    });
-  });
-  </script>
+  <!-- Table behaviour such as search, sort and detail toggling is provided -->
+  <!-- by table-tools.js so no inline handlers are needed here -->
   <script src="/table-tools.js"></script>
 </body>
 </html>

--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -37,7 +37,7 @@
       <th>Actions</th>
     </tr>
     <% Object.keys(sources).forEach(key => { %>
-      <tr class="sourceRow" data-key="<%= key %>">
+      <tr class="sourceRow toggle-row" data-key="<%= key %>">
         <td><%= key %></td>
         <td><%= sources[key].label %></td>
         <td class="status"><%= sourceStatus[key] || 'unknown' %></td>
@@ -49,7 +49,7 @@
           <button class="scrapeBtn">Scrape Now</button>
         </td>
       </tr>
-      <tr class="detailRow" data-key="<%= key %>" style="display:none">
+      <tr class="detailRow" data-key="<%= key %>">
         <td colspan="7">
           <div class="details">
             URL: <span class="url"><%= sources[key].url %></span><br>
@@ -96,7 +96,7 @@
       <th>Actions</th>
     </tr>
     <% Object.keys(awardSources).forEach(key => { %>
-      <tr class="awardSourceRow" data-key="<%= key %>">
+      <tr class="awardSourceRow toggle-row" data-key="<%= key %>">
         <td><%= key %></td>
         <td><%= awardSources[key].label %></td>
         <td class="status"><%= sourceStatus[key] || 'unknown' %></td>
@@ -108,7 +108,7 @@
           <button class="scrapeAwardBtn">Scrape Now</button>
         </td>
       </tr>
-      <tr class="awardDetailRow" data-key="<%= key %>" style="display:none">
+      <tr class="awardDetailRow" data-key="<%= key %>">
         <td colspan="7">
           <div class="details">
             URL: <span class="url"><%= awardSources[key].url %></span><br>
@@ -149,11 +149,6 @@ let editingAwardKey = null;
 // Expand row to show configuration details.
 document.querySelectorAll('.sourceRow').forEach(row => {
   const key = row.dataset.key;
-  row.addEventListener('click', e => {
-    if (e.target.closest('button')) return;
-    const detail = document.querySelector(`.detailRow[data-key="${key}"]`);
-    detail.style.display = detail.style.display === 'none' ? '' : 'none';
-  });
   row.querySelector('.testBtn').addEventListener('click', async e => {
     e.stopPropagation();
     row.querySelector('.status').textContent = 'testing...';
@@ -297,10 +292,6 @@ document.getElementById('addAwardSourceForm').addEventListener('submit', async e
 document.querySelectorAll('#awardSourceTable .awardSourceRow').forEach(row => {
   const key = row.dataset.key;
   const detail = document.querySelector(`.awardDetailRow[data-key="${key}"]`);
-  row.addEventListener('click', e => {
-    if (e.target.closest('button')) return;
-    detail.style.display = detail.style.display === 'none' ? '' : 'none';
-  });
   row.querySelector('.testAwardBtn').addEventListener('click', async e => {
     e.stopPropagation();
     row.querySelector('.status').textContent = 'testing...';

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,28 +1,33 @@
+/* Base typography and colours */
 body {
-  font-family: sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   padding: 2rem;
-  /* Light background so the table and form stand out */
-  background-color: #f9f9f9;
+  background: #f5f7fa;
+  color: #333;
 }
 table {
   width: 100%;
   border-collapse: collapse;
-  /* Separate the results table from the controls */
   margin-top: 1rem;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  overflow: hidden;
 }
 th,
 td {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
+  padding: 0.6rem;
+  border: 1px solid #dee2e6;
 }
 
 /* Highlight the table header and alternate rows for readability */
 th {
-  background-color: #eee;
+  background-color: #f1f3f5;
   text-align: left;
+  font-weight: 600;
 }
 tr:nth-child(even) {
-  background-color: #fafafa;
+  background-color: #f8f9fa;
 }
 
 /* Scrollable area showing progress messages during scraping */
@@ -48,16 +53,17 @@ tr:nth-child(even) {
 
 /* Consistent look for all buttons in the UI */
 button {
-  padding: 0.4rem 0.8rem;
-  background-color: #007bff;
+  padding: 0.45rem 0.9rem;
+  background-color: #0d6efd;
   color: #fff;
   border: none;
   border-radius: 4px;
   cursor: pointer;
+  transition: background-color 0.2s ease;
 }
 
 button:hover {
-  background-color: #0056b3;
+  background-color: #0b5ed7;
 }
 
 /* Highlighted callout containing usage help */
@@ -75,11 +81,12 @@ button:hover {
 
 /* Hide detail rows initially and give them a subtle background */
 .detailRow {
+  display: none;
   background: #f5f5f5;
 }
 
-/* Indicate that rows can be clicked to reveal more information */
-.tenderRow {
+/* Indicate that certain rows open additional details */
+.toggle-row {
   cursor: pointer;
 }
 
@@ -101,11 +108,12 @@ button:hover {
 }
 
 /* Tabbed navigation bar */
-.tabs { list-style:none; margin:0 0 1rem 0; padding:0; display:flex; border-bottom:1px solid #ccc; }
+.tabs { list-style:none; margin:0 0 1rem 0; padding:0; display:flex; border-bottom:1px solid #dee2e6; }
 .tabs li { margin:0; }
 .tabs li.right { margin-left:auto; }
-.tabs a { display:block; padding:0.5rem 1rem; text-decoration:none; border:1px solid #ccc; border-bottom:none; background:#eee; }
-.tabs li.active a { background:#fff; font-weight:bold; }
+.tabs a { display:block; padding:0.6rem 1rem; text-decoration:none; border:1px solid #dee2e6; border-bottom:none; background:#e9ecef; color:#333; }
+.tabs a:hover { background:#dee2e6; }
+.tabs li.active a { background:#fff; font-weight:600; }
 
 /* Status indicator circles used on the dashboard */
 .status-light { width:12px; height:12px; border-radius:50%; background:#ccc; display:inline-block; margin-right:0.5rem; }

--- a/frontend/table-tools.js
+++ b/frontend/table-tools.js
@@ -235,4 +235,24 @@ function enhanceTable(table) {
 // Automatically enhance all tables on the page once the DOM is ready
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('table').forEach(enhanceTable);
+  enableDetailRows();
 });
+
+/**
+ * Attach click handlers for rows that toggle a following detailRow. Any table
+ * row with the class "toggle-row" will show or hide the next sibling row if it
+ * has the class "detailRow". Links and buttons are ignored so other controls
+ * keep working as expected.
+ */
+function enableDetailRows(){
+  document.querySelectorAll('tr.toggle-row').forEach(row => {
+    const detail = row.nextElementSibling;
+    if(!detail || !detail.classList.contains('detailRow')) return;
+    // Start hidden in case serverside markup forgot the style attribute
+    detail.style.display = 'none';
+    row.addEventListener('click', e => {
+      if(e.target.closest('a') || e.target.closest('button')) return;
+      detail.style.display = detail.style.display === 'none' ? '' : 'none';
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- restyle pages with cleaner fonts, colours and nav
- hide detail rows by default
- reuse generic row toggling in `table-tools.js`
- remove duplicated inline click handlers

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cbab2de08328bff8f7a08f3db251