### PR TITLE
Enable inline editing from scraper table

### DIFF
--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -48,6 +48,7 @@
   <!-- Source list for tenders -->
   <details id="opportunitySources">
     <summary><h2>Opportunity Sources</h2></summary>
+    <p class="hint">Click a row to view details. Double-click to edit it.</p>
     <table id="sourceTable">
     <tr>
       <th>Key</th>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -90,6 +90,13 @@ button:hover {
   cursor: pointer;
 }
 
+/* Small helper text shown above tables */
+.hint {
+  margin-top: 0.25rem;
+  font-size: 0.9em;
+  color: #666;
+}
+
 /* Simple layout for the nested table shown inside detail rows */
 .detailRow table {
   width: 100%;

--- a/frontend/table-tools.js
+++ b/frontend/table-tools.js
@@ -254,5 +254,15 @@ function enableDetailRows(){
       if(e.target.closest('a') || e.target.closest('button')) return;
       detail.style.display = detail.style.display === 'none' ? '' : 'none';
     });
+    // Double click anywhere on the row to immediately open the edit form if
+    // one exists. This provides a quick way to modify entries without hunting
+    // for the small Edit button in the details panel.
+    row.addEventListener('dblclick', e => {
+      if(e.target.closest('a') || e.target.closest('button')) return;
+      // Ensure the detail row is visible before attempting to edit
+      detail.style.display = '';
+      const editBtn = detail.querySelector('.editBtn');
+      if(editBtn) editBtn.click();
+    });
   });
 }


### PR DESCRIPTION
## Summary
- allow double click to open edit mode for source tables
- show hint for row click instructions
- tweak CSS for hints

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d74060488328961a51bcd479f385