### PR TITLE
fix: avoid npm install conflict

### DIFF
--- a/scripts/rpi_bidfinder.sh
+++ b/scripts/rpi_bidfinder.sh
@@ -26,9 +26,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Ensure system packages are up to date and install Node.js and npm
+# Ensure system packages are up to date and then install Node.js.
+# The Node.js package from NodeSource already includes npm; installing the
+# separate `npm` package causes conflicts with this bundled version, so we
+# avoid installing it explicitly.
 sudo apt-get update
-sudo apt-get install -y nodejs npm
+sudo apt-get install -y nodejs
 
 # Install Node.js dependencies; limit to production packages when requested
 if [[ $PROD -eq 1 ]]; then


### PR DESCRIPTION
## Summary
- ensure rpi_bidfinder script installs only Node.js, as NodeSource bundles npm

## Testing
- `npm test` *(fails: 4 failing)*

------
https://chatgpt.com/codex/tasks/task_e_688f33c5892c8328918ec9afcf7ce599