### PR TITLE
fix: remove conflicting npm package before Node.js install

### DIFF
--- a/scripts/rpi_bidfinder.sh
+++ b/scripts/rpi_bidfinder.sh
@@ -31,6 +31,12 @@ done
 # separate `npm` package causes conflicts with this bundled version, so we
 # avoid installing it explicitly.
 sudo apt-get update
+
+# Remove any previously installed standalone npm package to avoid conflicts
+# with the bundled npm from NodeSource's Node.js package. Suppress errors if
+# npm is not present so the script can proceed.
+sudo apt-get purge -y npm || true
+
 sudo apt-get install -y nodejs
 
 # Install Node.js dependencies; limit to production packages when requested


### PR DESCRIPTION
## Summary
- purge any preinstalled standalone npm package before installing Node.js on Raspberry Pi setup script

## Testing
- `bash -n scripts/rpi_bidfinder.sh`
- `npm test` *(fails: getTenders retrieves rows ordered by date, parses Contracts Finder style HTML, scrapes every configured source, parses tenders from HTML and stores them)*

------
https://chatgpt.com/codex/tasks/task_e_6890c0800a0c83289ba397da9d702112