### PR TITLE
Add profile dropdown menu and account pages

### DIFF
--- a/frontend/learning-zone.ejs
+++ b/frontend/learning-zone.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Learning Zone</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Learning Zone</h1>
+  <!-- Navigation bar with dropdown menu -->
+  <%- include('partials/nav', { page: 'learning', user: user }) %>
+  <!-- On-screen instructions guide the user -->
+  <p>Access tutorials and resources to get the most from the application.</p>
+</body>
+</html>

--- a/frontend/manage-profiles.ejs
+++ b/frontend/manage-profiles.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Manage Profiles</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Manage Profiles</h1>
+  <!-- Navigation bar with profile menu -->
+  <%- include('partials/nav', { page: 'profiles', user: user }) %>
+  <!-- Guidance displayed so users understand the screen without reading docs -->
+  <p>Use this page to create and edit user profiles associated with your account.</p>
+</body>
+</html>

--- a/frontend/manage-users.ejs
+++ b/frontend/manage-users.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Manage Users</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Manage Users</h1>
+  <!-- Navigation with profile dropdown remains consistent -->
+  <%- include('partials/nav', { page: 'manage-users', user: user }) %>
+  <!-- Explain the purpose of the screen to avoid confusion -->
+  <p>Add, remove or update user accounts from this administration area.</p>
+</body>
+</html>

--- a/frontend/my-details.ejs
+++ b/frontend/my-details.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My Details</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>My Details</h1>
+  <!-- Shared navigation including profile actions -->
+  <%- include('partials/nav', { page: 'my-details', user: user }) %>
+  <!-- Simple explanation ensures users know what to do -->
+  <p>Review and update your personal information on this page.</p>
+</body>
+</html>

--- a/frontend/partials/nav.ejs
+++ b/frontend/partials/nav.ejs
@@ -7,8 +7,43 @@
   <li class="<%= page === 'stats' ? 'active' : '' %>"><a href="/stats">Stats</a></li>
   <li class="<%= page === 'help' ? 'active' : '' %>"><a href="/help">Help</a></li>
   <% if (user) { %>
-    <li class="right"><a href="/logout">Logout</a></li>
+    <!-- Profile dropdown shown when user is authenticated -->
+    <li class="right profile-menu">
+      <!-- Button displays user's initial as avatar -->
+      <button id="profileButton" aria-label="User menu" aria-expanded="false">
+        <span class="avatar"><%= user.username.charAt(0).toUpperCase() %></span>
+      </button>
+      <ul id="profileDropdown" class="profile-dropdown hidden">
+        <li><a href="/profiles">Manage Profiles</a></li>
+        <li><a href="/learning">Learning Zone</a></li>
+        <li><a href="/my-details">My Details</a></li>
+        <li><a href="/subscription">Subscription Details</a></li>
+        <li><a href="/manage-users">Manage Users</a></li>
+        <li><a href="/logout">Sign out</a></li>
+      </ul>
+    </li>
   <% } else { %>
     <li class="right"><a href="/login">Login</a></li>
   <% } %>
 </ul>
+<!-- Simple script toggles the profile dropdown for debugging and clarity -->
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('profileButton');
+    const menu = document.getElementById('profileDropdown');
+    if (btn && menu) {
+      // Toggle menu visibility when the avatar is clicked
+      btn.addEventListener('click', () => {
+        menu.classList.toggle('hidden');
+        btn.setAttribute('aria-expanded', !menu.classList.contains('hidden'));
+      });
+      // Hide the menu when clicking outside of it
+      document.addEventListener('click', evt => {
+        if (!btn.contains(evt.target) && !menu.contains(evt.target)) {
+          menu.classList.add('hidden');
+          btn.setAttribute('aria-expanded', 'false');
+        }
+      });
+    }
+  });
+</script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -153,3 +153,49 @@ details summary {
 details summary h2 {
   display: inline;
 }
+
+/* Profile menu styling positioned on the right of the navbar */
+.profile-menu {
+  position: relative;
+}
+.profile-menu button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.6rem;
+}
+.profile-menu .avatar {
+  background: #6c757d;
+  color: #fff;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+.profile-dropdown {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  position: absolute;
+  right: 0;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  z-index: 10;
+}
+.profile-dropdown li a {
+  display: block;
+  padding: 0.4rem 1rem;
+  text-decoration: none;
+  color: #333;
+}
+.profile-dropdown li a:hover {
+  background: #f1f3f5;
+}
+/* Utility class toggled via JavaScript */
+.hidden {
+  display: none;
+}

--- a/frontend/subscription-details.ejs
+++ b/frontend/subscription-details.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Subscription Details</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Subscription Details</h1>
+  <!-- Reuse navigation bar so user can reach other pages easily -->
+  <%- include('partials/nav', { page: 'subscription', user: user }) %>
+  <!-- Short description of what this page provides -->
+  <p>View billing and plan information for your subscription.</p>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -341,6 +341,38 @@ app.get('/logout', (req, res) => {
   req.session.destroy(() => res.redirect('/'));
 });
 
+// Profile and account management pages -------------------------------------
+
+// Display placeholder screen for managing multiple profiles
+app.get('/profiles', requireAuth, (req, res) => {
+  logger.info('User %s accessed Manage Profiles', req.session.user.username);
+  res.render('manage-profiles', { page: 'profiles' });
+});
+
+// Provide learning resources to the user
+app.get('/learning', requireAuth, (req, res) => {
+  logger.info('User %s opened Learning Zone', req.session.user.username);
+  res.render('learning-zone', { page: 'learning' });
+});
+
+// Show editable details for the current account
+app.get('/my-details', requireAuth, (req, res) => {
+  logger.info('User %s viewing My Details', req.session.user.username);
+  res.render('my-details', { page: 'my-details' });
+});
+
+// Present subscription and billing information
+app.get('/subscription', requireAuth, (req, res) => {
+  logger.info('User %s viewing Subscription Details', req.session.user.username);
+  res.render('subscription-details', { page: 'subscription' });
+});
+
+// Administration area for managing other users
+app.get('/manage-users', requireAuth, (req, res) => {
+  logger.info('User %s accessed Manage Users', req.session.user.username);
+  res.render('manage-users', { page: 'manage-users' });
+});
+
 // POST /sources - Add a new scraping source at runtime. The request should
 // include a unique key along with label, url and base properties. Sources are
 // stored in memory so they persist only for the lifetime of the process.


### PR DESCRIPTION
## Summary
- add profile avatar dropdown to navigation bar
- create placeholder screens for profiles, learning zone, account details, subscription, and user management
- log access to new account routes

## Testing
- `npm test` *(fails: htmlParser parses Contracts Finder style HTML: expected 'View' to equal 'Contract A'; scrape.runAll expected +0 to equal 2; scrape.run expected +0 to equal 2)*

------
https://chatgpt.com/codex/tasks/task_e_6892077b188c8328b7d7f4805b7a31b4