### PR TITLE
feat: show scrape date in tender tables

### DIFF
--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -13,6 +13,8 @@
       <th data-type="date">Date</th>
       <th>Description</th>
       <th data-type="source">Source</th>
+      <!-- Track when each award was retrieved -->
+      <th data-type="date">Date Scraped</th>
       <th data-type="date">Scraped At</th>
       <th>Tags</th>
       <th>Link</th>
@@ -23,18 +25,24 @@
         <td><%= t.date %></td>
         <td><%= t.description %></td>
         <td><%= t.source %></td>
+        <!-- Date only keeps table compact -->
+        <td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td>
+        <!-- Full timestamp available for investigations -->
         <td><%= t.scraped_at %></td>
         <td><%= t.tags %></td>
         <!-- Open award links in a new tab to keep the list available -->
         <td><a href="<%= t.link %>" target="_blank">View</a></td>
       </tr>
       <tr class="detailRow" data-id="<%= t.id %>">
-        <td colspan="7">
+        <td colspan="8">
           <table>
             <tr><th>Title</th><td><%= t.title %></td></tr>
             <tr><th>Date</th><td><%= t.date %></td></tr>
             <tr><th>Description</th><td><%= t.description %></td></tr>
             <tr><th>Source</th><td><%= t.source %></td></tr>
+            <!-- Date component for quick reference -->
+            <tr><th>Date Scraped</th><td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td></tr>
+            <!-- Timestamp for precise audit trail -->
             <tr><th>Scraped At</th><td><%= t.scraped_at %></td></tr>
             <tr><th>Tags</th><td><%= t.tags %></td></tr>
             <tr><th>Link</th><td><a href="<%= t.link %>" target="_blank"><%= t.link %></a></td></tr>
@@ -43,7 +51,7 @@
       </tr>
     <% }) %>
     <% if (tenders.length === 0) { %>
-      <tr><td colspan="7">No awarded contracts found. Scrape an award source to populate this list.</td></tr>
+      <tr><td colspan="8">No awarded contracts found. Scrape an award source to populate this list.</td></tr>
     <% } %>
   </table>
   <!-- table-tools.js handles row detail toggling and table utilities -->

--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -13,6 +13,8 @@
       <th data-type="date">Date</th>
       <th>Description</th>
       <th data-type="source">Source</th>
+      <!-- New column showing when the tender was scraped (date only) -->
+      <th data-type="date">Date Scraped</th>
       <th data-type="date">Scraped At</th>
       <th>Tags</th>
       <th>Link</th>
@@ -24,18 +26,24 @@
         <td><%= t.date %></td>
         <td><%= t.description %></td>
         <td><%= t.source %></td>
+        <!-- Strip time for concise display -->
+        <td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td>
+        <!-- Full timestamp retained for precise auditing -->
         <td><%= t.scraped_at %></td>
         <td><%= t.tags %></td>
         <!-- Open tender links in a new tab so the dashboard stays visible -->
         <td><a href="<%= t.link %>" target="_blank">View</a></td>
       </tr>
       <tr class="detailRow" data-id="<%= t.id %>">
-        <td colspan="7">
+        <td colspan="8">
           <table>
             <tr><th>Title</th><td><%= t.title %></td></tr>
             <tr><th>Date</th><td><%= t.date %></td></tr>
             <tr><th>Description</th><td><%= t.description %></td></tr>
             <tr><th>Source</th><td><%= t.source %></td></tr>
+            <!-- Date only field aids quick visual scanning -->
+            <tr><th>Date Scraped</th><td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td></tr>
+            <!-- Raw timestamp preserved for debugging -->
             <tr><th>Scraped At</th><td><%= t.scraped_at %></td></tr>
             <tr><th>Tags</th><td><%= t.tags %></td></tr>
             <tr><th>Link</th><td><a href="<%= t.link %>" target="_blank"><%= t.link %></a></td></tr>
@@ -44,7 +52,7 @@
       </tr>
     <% }) %>
   <% if (tenders.length === 0) { %>
-      <tr><td colspan="7">No opportunities found. Try running the scraper.</td></tr>
+      <tr><td colspan="8">No opportunities found. Try running the scraper.</td></tr>
   <% } %>
   </table>
   <div class="server-pagination">


### PR DESCRIPTION
## Summary
- display when tenders were scraped in opportunities and awarded tables
- keep full timestamp for auditing while showing date for quick scan

## Testing
- `npm test` *(fails: getTenders retrieves rows ordered by date, parses Contracts Finder style HTML, scrapes every configured source, parses tenders from HTML and stores them)*

------
https://chatgpt.com/codex/tasks/task_e_689215065e748328bb8d24eeca6bf39e