### PR TITLE
Remove duplicate pagination indicators on opportunities page

### DIFF
--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -7,7 +7,9 @@
 <body>
   <h1>Opportunities</h1>
   <%- include('partials/nav', { page: 'opportunities', user: user }) %>
-  <table>
+  <!-- data-server-pagination tells table-tools.js that navigation is handled
+       by the server so client side pagination should be disabled -->
+  <table data-server-pagination="true">
     <tr>
       <th>Title</th>
       <th data-type="date">Date</th>


### PR DESCRIPTION
## Summary
- avoid rendering client-side pager when server already paginates opportunities table
- mark opportunities table as server paginated to hide extra page indicator

## Testing
- `npm test` *(fails: 4 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68921541d1548328beee6079b14a2bf1