### PR TITLE
Remove redundant Date Scraped column

### DIFF
--- a/frontend/awarded.ejs
+++ b/frontend/awarded.ejs
@@ -14,7 +14,6 @@
       <th>Description</th>
       <th data-type="source">Source</th>
       <!-- Track when each award was retrieved -->
-      <th data-type="date">Date Scraped</th>
       <th data-type="date">Scraped At</th>
       <th>Tags</th>
       <th>Link</th>
@@ -25,8 +24,6 @@
         <td><%= t.date %></td>
         <td><%= t.description %></td>
         <td><%= t.source %></td>
-        <!-- Date only keeps table compact -->
-        <td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td>
         <!-- Full timestamp available for investigations -->
         <td><%= t.scraped_at %></td>
         <td><%= t.tags %></td>
@@ -34,14 +31,12 @@
         <td><a href="<%= t.link %>" target="_blank">View</a></td>
       </tr>
       <tr class="detailRow" data-id="<%= t.id %>">
-        <td colspan="8">
+        <td colspan="7">
           <table>
             <tr><th>Title</th><td><%= t.title %></td></tr>
             <tr><th>Date</th><td><%= t.date %></td></tr>
             <tr><th>Description</th><td><%= t.description %></td></tr>
             <tr><th>Source</th><td><%= t.source %></td></tr>
-            <!-- Date component for quick reference -->
-            <tr><th>Date Scraped</th><td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td></tr>
             <!-- Timestamp for precise audit trail -->
             <tr><th>Scraped At</th><td><%= t.scraped_at %></td></tr>
             <tr><th>Tags</th><td><%= t.tags %></td></tr>
@@ -51,7 +46,7 @@
       </tr>
     <% }) %>
     <% if (tenders.length === 0) { %>
-      <tr><td colspan="8">No awarded contracts found. Scrape an award source to populate this list.</td></tr>
+      <tr><td colspan="7">No awarded contracts found. Scrape an award source to populate this list.</td></tr>
     <% } %>
   </table>
   <!-- table-tools.js handles row detail toggling and table utilities -->

--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -15,8 +15,7 @@
       <th data-type="date">Date</th>
       <th>Description</th>
       <th data-type="source">Source</th>
-      <!-- New column showing when the tender was scraped (date only) -->
-      <th data-type="date">Date Scraped</th>
+      <!-- Timestamp indicating when each tender was scraped -->
       <th data-type="date">Scraped At</th>
       <th>Tags</th>
       <th>Link</th>
@@ -28,23 +27,19 @@
         <td><%= t.date %></td>
         <td><%= t.description %></td>
         <td><%= t.source %></td>
-        <!-- Strip time for concise display -->
-        <td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td>
-        <!-- Full timestamp retained for precise auditing -->
+        <!-- Full timestamp retained for precise auditing and debugging -->
         <td><%= t.scraped_at %></td>
         <td><%= t.tags %></td>
         <!-- Open tender links in a new tab so the dashboard stays visible -->
         <td><a href="<%= t.link %>" target="_blank">View</a></td>
       </tr>
       <tr class="detailRow" data-id="<%= t.id %>">
-        <td colspan="8">
+        <td colspan="7">
           <table>
             <tr><th>Title</th><td><%= t.title %></td></tr>
             <tr><th>Date</th><td><%= t.date %></td></tr>
             <tr><th>Description</th><td><%= t.description %></td></tr>
             <tr><th>Source</th><td><%= t.source %></td></tr>
-            <!-- Date only field aids quick visual scanning -->
-            <tr><th>Date Scraped</th><td><%= t.scraped_at ? t.scraped_at.slice(0,10) : '' %></td></tr>
             <!-- Raw timestamp preserved for debugging -->
             <tr><th>Scraped At</th><td><%= t.scraped_at %></td></tr>
             <tr><th>Tags</th><td><%= t.tags %></td></tr>
@@ -54,7 +49,7 @@
       </tr>
     <% }) %>
   <% if (tenders.length === 0) { %>
-      <tr><td colspan="8">No opportunities found. Try running the scraper.</td></tr>
+      <tr><td colspan="7">No opportunities found. Try running the scraper.</td></tr>
   <% } %>
   </table>
   <div class="server-pagination">


### PR DESCRIPTION
## Summary
- Drop duplicate Date Scraped column from opportunities and awarded templates
- Show only Scraped At timestamp for each tender and adjust table structure

## Testing
- `npm test` *(fails: expected 3 rows but got 4; parses Contracts Finder style HTML; scrapes every configured source; parses tenders from HTML and stores them)*

------
https://chatgpt.com/codex/tasks/task_e_68922983a02483288f8ea86fe770eec0