### PR TITLE
feat(server): use secure persistent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,24 @@ in the database allowing future filters by procurement category.
 ## Setup
 
 1. Install dependencies:
-   ```bash
-   npm install
-   ```
+ ```bash
+  npm install
+  ```
 2. Initialise the database:
-   ```bash
-   npm run init-db
-   ```
-3. Start the server:
+  ```bash
+  npm run init-db
+  ```
+3. Set a strong session secret so login cookies can be safely signed. Replace
+   the example text with your own random string.
+   - **Linux/macOS/Raspberry Pi**
+     ```bash
+     export SESSION_SECRET="change_me_to_a_random_string"
+     ```
+   - **Windows PowerShell**
+     ```powershell
+     $env:SESSION_SECRET="change_me_to_a_random_string"
+     ```
+4. Start the server:
    ```bash
    node server/index.js
    ```
@@ -64,6 +74,9 @@ provide a port number to immediately launch the application:
 - `HOST` - interface the server listens on (default `0.0.0.0`).
 - `FRONTEND_DIR` - directory for templates and static files.
 - `DB_FILE` - path to the SQLite database file.
+- `SESSION_SECRET` - **required** secret used to sign session cookies. The server
+  exits on startup if this is missing. Generate a long random string for
+  production use.
 - `SCRAPE_URL` - URL used to fetch tender data for the default Contracts Finder feed.
 - `SCRAPE_BASE` - base URL prepended to scraped tender links.
 - `EUSUPPLY_URL` and `EUSUPPLY_BASE` - overrides for the built-in EU Supply source.
@@ -107,6 +120,13 @@ All console output is also written to `logs/app.log` so you can review what the
 scraper was doing after it finishes. The log file persists across restarts and
 includes messages for every tender processed. If no new tenders are stored the
 log will explain whether none were found or all were detected as duplicates.
+
+## Session storage
+
+User login sessions persist across server restarts using a small SQLite database
+(`sessions.sqlite`) created in the project root. The database is managed via the
+`connect-sqlite3` library and can be safely backed up or removed to clear all
+sessions.
 
 ## Adding new sources
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "node-fetch": "^2.6.7",
     "node-cron": "^3.0.2",
     "express-session": "^1.17.3",
-    "bcryptjs": "^2.4.3"
+    "bcryptjs": "^2.4.3",
+    "connect-sqlite3": "^0.9.0"
   },
   "devDependencies": {
     "chai": "^4.3.7",


### PR DESCRIPTION
## Summary
- require `SESSION_SECRET` and exit when missing
- persist sessions to SQLite and secure cookies with strict flags
- document session configuration and secret in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/connect-sqlite3)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ba6f9b988328b097dd7a3ee50ac6