### PR TITLE
feat: secure responses with Helmet CSP

### DIFF
--- a/helmet.js
+++ b/helmet.js
@@ -1,0 +1,35 @@
+/**
+ * @file helmet.js
+ * @description Lightweight fallback implementation mimicking a subset of the
+ * Helmet middleware for environments where the official package cannot be
+ * installed. It sets a few common security headers including an optional
+ * Content Security Policy.
+ *
+ * Structure:
+ * - Build Content-Security-Policy string from provided directives.
+ * - Return Express middleware function applying security headers.
+ */
+module.exports = function helmet(options = {}) {
+  const directives =
+    options.contentSecurityPolicy && options.contentSecurityPolicy.directives;
+  let csp;
+  if (directives) {
+    csp = Object.entries(directives)
+      .map(([key, value]) => {
+        const headerName = key.replace(/([A-Z])/g, m => '-' + m.toLowerCase());
+        return `${headerName} ${value.join(' ')}`;
+      })
+      .join('; ');
+  }
+  return function helmetMiddleware(req, res, next) {
+    // Basic headers equivalent to Helmet defaults
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    if (csp) {
+      res.setHeader('Content-Security-Policy', csp);
+    }
+    next();
+  };
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node server/index.js",
     "init-db": "node server/init-db.js",
-    "test": "mocha"
+    "test": "NODE_PATH=. mocha"
   },
   "dependencies": {
     "express": "^4.19.2",
@@ -14,6 +14,7 @@
     "node-fetch": "^2.6.12",
     "node-cron": "^3.0.3",
     "express-session": "^1.18.0",
+    "helmet": "^7.0.0",
     "bcryptjs": "^2.4.3",
     "connect-sqlite3": "^0.9.0"
   },

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,8 @@
  */
 const express = require('express');
 const session = require('express-session');
+// Helmet hardens HTTP responses with security-related headers.
+const helmet = require('helmet');
 // Persist session data to disk so that logins survive server restarts.
 const SQLiteStore = require('connect-sqlite3')(session);
 const path = require('path');
@@ -152,6 +154,23 @@ function openBrowser(url) {
   }
   await scheduleJob();
 })();
+
+// Apply security headers before any routes are defined. The Content Security
+// Policy restricts scripts and styles to this server only, with inline
+// allowances for legacy templates that embed small snippets.
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:'],
+        connectSrc: ["'self'"]
+      }
+    }
+  })
+);
 
 // Parse JSON request bodies so the UI can post new sources
 app.use(express.json());

--- a/test/security-headers.test.js
+++ b/test/security-headers.test.js
@@ -1,0 +1,37 @@
+/**
+ * @file security-headers.test.js
+ * @description Verifies that global security headers such as the Content
+ * Security Policy are applied via Helmet. Ensures responses contain the
+ * expected protection headers.
+ *
+ * Structure:
+ * - Configure environment for in-memory operation.
+ * - Spin up the Express application on a random port.
+ * - Issue a request and assert key security headers are present.
+ */
+const { expect } = require('chai');
+const http = require('http');
+const fetch = require('node-fetch');
+
+process.env.DB_FILE = ':memory:';
+process.env.SESSION_SECRET = 'test-secret';
+
+const { app } = require('../server/index');
+let server;
+const url = path => `http://127.0.0.1:${server.address().port}${path}`;
+
+before(async () => {
+  server = http.createServer(app).listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+});
+
+after(() => server.close());
+
+describe('security headers', () => {
+  it('includes CSP and other Helmet headers', async () => {
+    const res = await fetch(url('/login'));
+    expect(res.headers.get('content-security-policy')).to.include("default-src 'self'");
+    expect(res.headers.get('x-content-type-options')).to.equal('nosniff');
+    expect(res.headers.get('x-dns-prefetch-control')).to.equal('off');
+  });
+});


### PR DESCRIPTION
## Summary
- apply Helmet middleware to send security headers and a restrictive CSP
- stub minimal Helmet implementation for environments without npm
- test security headers to ensure CSP and related headers are present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f40ceba48328a351fb432453c963