### PR TITLE
Capture tender detail fields and import CPV codes

### DIFF
--- a/test/db.test.js
+++ b/test/db.test.js
@@ -18,7 +18,13 @@ describe('Database helpers', () => {
       '2024-01-02T00:00:00Z',
       'tag1',
       'ocds-x',
-      '12345678'
+      '12345678',
+      '2024-01-01',
+      '2024-02-01',
+      'Buyer',
+      'Addr',
+      'Country',
+      'Eligibility'
     );
     const second = await db.insertTender(
       't1',
@@ -29,7 +35,13 @@ describe('Database helpers', () => {
       '2024-01-02T00:00:00Z',
       'tag1',
       'ocds-x',
-      '12345678'
+      '12345678',
+      '2024-01-01',
+      '2024-02-01',
+      'Buyer',
+      'Addr',
+      'Country',
+      'Eligibility'
     );
     expect(first).to.equal(1);
     expect(second).to.equal(0);
@@ -45,7 +57,13 @@ describe('Database helpers', () => {
       '2024-01-02T00:00:00Z',
       '',
       'ocds-dedupe',
-      '23456789'
+      '23456789',
+      '',
+      '',
+      '',
+      '',
+      '',
+      ''
     );
     const second = await db.insertTender(
       'tO2',
@@ -56,7 +74,13 @@ describe('Database helpers', () => {
       '2024-01-03T00:00:00Z',
       '',
       'ocds-dedupe',
-      '23456789'
+      '23456789',
+      '',
+      '',
+      '',
+      '',
+      '',
+      ''
     );
     expect(first).to.equal(1);
     expect(second).to.equal(0);
@@ -64,8 +88,8 @@ describe('Database helpers', () => {
 
   it('getTenders retrieves rows ordered by date', async () => {
     // Insert two tenders with different dates
-    await db.insertTender('t2', 'link2', '2024-02-01', 'd', 's', '2024-02-02T00:00:00Z', 'tag', 'ocds-2', '11111111');
-    await db.insertTender('t3', 'link3', '2024-03-01', 'd', 's', '2024-03-02T00:00:00Z', 'tag', 'ocds-3', '22222222');
+    await db.insertTender('t2', 'link2', '2024-02-01', 'd', 's', '2024-02-02T00:00:00Z', 'tag', 'ocds-2', '11111111', '', '', '', '', '', '');
+    await db.insertTender('t3', 'link3', '2024-03-01', 'd', 's', '2024-03-02T00:00:00Z', 'tag', 'ocds-3', '22222222', '', '', '', '', '', '');
     const rows = await db.getTenders();
     // There are now four rows in total including earlier inserts.
     expect(rows).to.have.length(4);
@@ -78,6 +102,9 @@ describe('Database helpers', () => {
     expect(rows[0]).to.have.property('tags');
     expect(rows[0]).to.have.property('ocid');
     expect(rows[0]).to.have.property('cpv');
+    expect(rows[0]).to.have.property('open_date');
+    expect(rows[0]).to.have.property('deadline');
+    expect(rows[0]).to.have.property('customer');
   });
 
   it('cron schedule can be stored and retrieved', async () => {
@@ -182,8 +209,8 @@ describe('Database helpers', () => {
   });
 
   it('deleteTendersBefore removes only old rows', async () => {
-    await db.insertTender('new', 'n1', '2024-05-01', 'd', 's', '2024-05-02T00:00:00Z', 't', 'ocds-n', '99999999');
-    await db.insertTender('old', 'o1', '2023-01-01', 'd', 's', '2023-01-02T00:00:00Z', 't', 'ocds-o', '88888888');
+    await db.insertTender('new', 'n1', '2024-05-01', 'd', 's', '2024-05-02T00:00:00Z', 't', 'ocds-n', '99999999', '', '', '', '', '', '');
+    await db.insertTender('old', 'o1', '2023-01-01', 'd', 's', '2023-01-02T00:00:00Z', 't', 'ocds-o', '88888888', '', '', '', '', '', '');
     await db.deleteTendersBefore('2024-01-01');
     const rows = await db.getTenders();
     const titles = rows.map(r => r.title);

--- a/test/detailParser.test.js
+++ b/test/detailParser.test.js
@@ -67,9 +67,30 @@ transportationprocurement@kier.co.uk`;
 });
 
 describe('parseTenderDetails', () => {
-  it('extracts unique CPV codes from HTML', () => {
-    const html = '<div>CPV: 12345678, 12345678 and 87654321</div>';
+  it('extracts fields from tender page text', () => {
+    const html = `Published date
+1 May 2024
+Closing date
+10 May 2024
+Name of buying organisation
+Big Buyer Ltd
+Address
+1 Street
+Country
+England
+Description
+Work on something
+Eligibility
+SME only
+CPV: 12345678 and 87654321`;
     const d = parseTenderDetails(html);
     expect(d.cpv).to.deep.equal(['12345678', '87654321']);
+    expect(d.open_date).to.equal('1 May 2024');
+    expect(d.deadline).to.equal('10 May 2024');
+    expect(d.customer).to.equal('Big Buyer Ltd');
+    expect(d.address).to.equal('1 Street');
+    expect(d.country).to.equal('England');
+    expect(d.description).to.equal('Work on something');
+    expect(d.eligibility).to.equal('SME only');
   });
 });

--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -3,10 +3,10 @@ const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 const { expect } = require('chai');
 
-it('adds ocid and cpv columns if missing', async () => {
+it('adds missing columns if absent', async () => {
   const file = path.join(__dirname, 'migrate.db');
   if (fs.existsSync(file)) fs.unlinkSync(file);
-  // Create old schema without ocid or cpv columns
+  // Create old schema without newer columns like ocid or cpv
   const oldDb = new sqlite3.Database(file);
   await new Promise(res => oldDb.run(`CREATE TABLE tenders (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -25,9 +25,10 @@ it('adds ocid and cpv columns if missing', async () => {
   delete require.cache[require.resolve('../server/db')];
   const db = require('../server/db');
 
-  await db.insertTender('t', 'l', '2024-01-01', 'd', 's', '2024-01-02', 'tag', 'ocid-1', '12345678');
+  await db.insertTender('t', 'l', '2024-01-01', 'd', 's', '2024-01-02', 'tag', 'ocid-1', '12345678', '', '', '', '', '', '');
   const rows = await db.getTenders();
   expect(rows[0].ocid).to.equal('ocid-1');
   expect(rows[0].cpv).to.equal('12345678');
+  expect(rows[0]).to.have.property('open_date');
   fs.unlinkSync(file);
 });


### PR DESCRIPTION
## Summary
- expand tender database schema to hold deadline, open date, buyer and location fields
- parse tender detail pages for CPV codes and new metadata
- load official CPV code list into `cpv_codes` table during DB initialisation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f61760cc8328b3b5e1081ce933fc