### PR TITLE
Launch server in background on Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,19 @@ in the database allowing future filters by procurement category.
 
 The repository includes small helper scripts for Raspberry Pi systems. Run the
 setup script once to install Node.js, initialise the database and optionally
-start the server. Pass the `-p` flag to install only production dependencies and
-provide a port number to immediately launch the application:
+start the server. Pass the `-p` flag to install only production dependencies.
+Supplying a port starts the server in the background and writes logs to
+`logs/app.log` so the script returns to the shell immediately:
 
 ```bash
 ./scripts/rpi_bidfinder.sh -p 4000
+tail -f logs/app.log    # monitor server logs
+```
+
+Stop the server later with:
+
+```bash
+pkill -f "node server/index.js"
 ```
 
 ## Usage

--- a/scripts/rpi_bidfinder.sh
+++ b/scripts/rpi_bidfinder.sh
@@ -50,8 +50,11 @@ fi
 npm run init-db # create the SQLite database
 
 # Launch the application when a port number is supplied. The run.sh helper
-# exports PORT before starting the Node.js server.
+# exports PORT before starting the Node.js server. The server is started in the
+# background so this script exits immediately.
 if [[ -n "$PORT" ]]; then
   ./scripts/run.sh "$PORT"
 fi
+
+echo "Setup complete."
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# run.sh - convenience wrapper to launch the server.
+# run.sh - convenience wrapper to launch the Procurement Scraper GUI server.
 # Usage: ./scripts/run.sh [PORT]
-# When a port number is provided it is exported as the PORT
-# environment variable so the Express application listens
-# on that interface.
+#
+# Accepts an optional port argument which is exported as the PORT environment
+# variable so the Express application listens on that interface. The server is
+# started in the background to avoid blocking the calling script. Logs continue
+# to be written to logs/app.log by the application's logger.
 
 set -e
 
@@ -13,5 +15,11 @@ if [ -n "$1" ]; then
   export PORT="$1"
 fi
 
-# Start the Node.js backend.
-node server/index.js
+# Start the Node.js backend in the background. Use nohup so the server keeps
+# running even if the launching terminal closes. Suppress stdout/stderr as the
+# application already logs to logs/app.log.
+nohup node server/index.js >/dev/null 2>&1 &
+SERVER_PID=$!
+
+echo "Server started in background on port ${PORT:-3000} (PID: $SERVER_PID)"
+echo "View logs with: tail -f logs/app.log"


### PR DESCRIPTION
## Summary
- avoid blocking scripts by launching Node server in the background with `nohup`
- note background behaviour in Raspberry Pi setup script and README instructions
- clarify how to monitor logs and stop the server

## Testing
- `npm test -- --exit`


------
https://chatgpt.com/codex/tasks/task_e_6894ff923a3c8328b43ebe5bce0bce27