### PR TITLE
Add selector-driven tender parsing support

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -21,6 +21,11 @@ const defaultSource = {
 // Other sources previously included here have been removed as they either no
 // longer work or never provided reliable results. A small selection is kept to
 // demonstrate multiple scraping strategies.
+//
+// Sources can optionally define a `selectors` object describing CSS selectors
+// for the title, link, date and description fields. When provided the scraper
+// delegates parsing to the generic CSS-driven parser, making it easy to add new
+// HTML portals without shipping additional code.
 
 const euSupplySource = {
   label: 'EU Supply UK',
@@ -28,7 +33,15 @@ const euSupplySource = {
     process.env.EUSUPPLY_URL ||
     'https://uk.eu-supply.com/ctm/supplier/publictenders?B=UK',
   base: process.env.EUSUPPLY_BASE || 'https://uk.eu-supply.com',
-  parser: 'eusupply'
+  parser: 'generic',
+  selectors: {
+    // Each row in the tender listing table contains a single opportunity.
+    item: 'tr',
+    title: 'a',
+    link: { selector: 'a', attr: 'href' },
+    date: ['time', 'td:nth-child(3)'],
+    description: ['td.description', 'p']
+  }
 };
 
 // Example Sell2Wales source used by the additional `sell2wales` parser.

--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -4,6 +4,7 @@
  *
  * Structure:
  *   - clean: normalises text by stripping tags and whitespace.
+ *   - parseGeneric
  *   - parseContractsFinder
  *   - parseSell2Wales
  *   - parseUkri
@@ -22,7 +23,197 @@ const cheerio = require('cheerio');
  * @returns {string} Cleaned string.
  */
 function clean(str = '') {
-  return cheerio.load(str).text().replace(/\s+/g, ' ').trim();
+  const safe = typeof str === 'string' ? str : str == null ? '' : String(str);
+  return cheerio.load(safe).text().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Attempt to resolve a cheerio element according to the supplied selector
+ * definition. Strings are treated as CSS selectors searched within the
+ * provided block, whereas objects allow specifying alternate lookup
+ * strategies such as `closest` or retrieving the block itself using `self`.
+ * Arrays are processed until a non-empty match is found.
+ *
+ * @param {cheerio.Cheerio} block The element representing a single tender.
+ * @param {string|object|Array} def Selector definition.
+ * @returns {cheerio.Cheerio|null} Matched element or null when nothing is found.
+ */
+function resolveElement(block, def) {
+  if (!def) return null;
+
+  if (Array.isArray(def)) {
+    for (const candidate of def) {
+      const el = resolveElement(block, candidate);
+      if (el && el.length) {
+        return el;
+      }
+    }
+    return null;
+  }
+
+  if (typeof def === 'string') {
+    if (def === ':self' || def === 'self') {
+      return block;
+    }
+    const el = block.find(def).first();
+    return el.length ? el : null;
+  }
+
+  if (typeof def === 'object') {
+    if (def.self) {
+      return block;
+    }
+
+    const strategy = def.strategy || (def.closest ? 'closest' : 'find');
+    const selector = def.selector || def.closest || def.find;
+
+    if (!selector) {
+      return block;
+    }
+
+    const el =
+      strategy === 'closest'
+        ? block.closest(selector)
+        : strategy === 'self'
+        ? block
+        : block.find(selector).first();
+
+    return el && el.length ? el : null;
+  }
+
+  return null;
+}
+
+/**
+ * Extract text or attribute data from a block using the provided selector.
+ * When `options.attribute` is supplied the corresponding attribute value is
+ * returned rather than element text. Multiple selectors can be passed via an
+ * array to provide fallbacks.
+ *
+ * @param {cheerio.Cheerio} block Tender wrapper element.
+ * @param {string|object|Array} def Selector definition.
+ * @param {{attribute?: string, cleanText?: boolean}} [options] Extraction opts.
+ * @returns {string} Resolved value (empty string when no match is found).
+ */
+function extractValue(block, def, options = {}) {
+  const { attribute, cleanText = true } = options;
+  const selectors = Array.isArray(def) ? def : [def];
+
+  for (const selectorDef of selectors) {
+    if (!selectorDef) continue;
+
+    let attrName = attribute;
+    if (typeof selectorDef === 'object' && selectorDef.attr && !attrName) {
+      attrName = selectorDef.attr;
+    }
+
+    const el = resolveElement(block, selectorDef);
+    if (!el || !el.length) {
+      continue;
+    }
+
+    if (attrName) {
+      const raw = el.attr(attrName);
+      if (typeof raw === 'string' && raw.trim()) {
+        return cleanText ? clean(raw) : raw.trim();
+      }
+      continue;
+    }
+
+    const html = el.html();
+    if (typeof html === 'string' && html.trim()) {
+      return clean(html);
+    }
+
+    const text = el.text();
+    if (typeof text === 'string' && text.trim()) {
+      return clean(text);
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Generic parser that can be configured via CSS selectors. Each selector is
+ * applied relative to a wrapper element identified by `selectors.item`. When
+ * `item` is omitted the selector supplied for the link or title is used as the
+ * iteration anchor, allowing quick experiments albeit with less context.
+ *
+ * @param {string} html Raw HTML fragment to parse.
+ * @param {object} selectors Map of selector strings/objects.
+ * @param {string|object|Array} selectors.item CSS selector locating each row.
+ * @param {string|object|Array} selectors.title Selector yielding the title.
+ * @param {string|object|Array} selectors.link Selector yielding the link.
+ * @param {string|object|Array} [selectors.date] Selector for the date field.
+ * @param {string|object|Array} [selectors.description] Selector for the summary.
+ * @returns {Array<object>} Normalised tender objects.
+ */
+function parseGeneric(html, selectors = {}) {
+  const $ = cheerio.load(html);
+  const results = [];
+
+  const itemSelector = selectors.item || selectors.items || null;
+  const anchorSelector = selectors.link || selectors.title || 'a';
+  const nodes = itemSelector ? $(itemSelector).toArray() : $(anchorSelector).toArray();
+  const seen = new Set();
+
+  for (const node of nodes) {
+    const base = itemSelector ? $(node) : $(node);
+    const block = !itemSelector && selectors.scope ? base.closest(selectors.scope) : base;
+
+    const title = selectors.title
+      ? extractValue(block, selectors.title)
+      : extractValue(block, ['h1', 'h2', 'h3', 'a']);
+
+    const linkAttr =
+      (typeof selectors.link === 'object' && selectors.link.attr) ||
+      selectors.linkAttribute ||
+      'href';
+    const linkEl = selectors.link ? selectors.link : { selector: 'a', attr: 'href' };
+    const link = extractValue(block, linkEl, { attribute: linkAttr, cleanText: false });
+
+    if (!title || !link) {
+      continue;
+    }
+
+    const key = `${title}|${link}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    const tender = {
+      title,
+      link,
+      date: selectors.date ? extractValue(block, selectors.date) : '',
+      desc: selectors.description ? extractValue(block, selectors.description) : '',
+      organisation: selectors.organisation ? extractValue(block, selectors.organisation) : '',
+      supplier: selectors.supplier ? extractValue(block, selectors.supplier) : ''
+    };
+
+    const ocidAttr =
+      (typeof selectors.ocid === 'object' && selectors.ocid.attr) || selectors.ocidAttribute;
+    let ocid = selectors.ocid
+      ? extractValue(block, selectors.ocid, {
+          attribute: ocidAttr,
+          cleanText: !ocidAttr
+        })
+      : '';
+
+    if (!ocid) {
+      ocid =
+        block.attr('data-ocid') ||
+        block.find('[data-ocid]').attr('data-ocid') ||
+        (block.text().match(/ocds-[a-z0-9-]+/i) || [])[0] ||
+        '';
+    }
+
+    tender.ocid = ocid;
+    results.push(tender);
+  }
+
+  return results;
 }
 
 /**
@@ -234,10 +425,27 @@ function parseRss(xml) {
 }
 
 /**
- * Dispatch parser based on source key.
+ * Dispatch parser based on source configuration. When a selectors object is
+ * supplied the new generic parser is used; otherwise the legacy named parsers
+ * remain available for backwards compatibility and specialised behaviour.
+ *
+ * @param {string} html Raw HTML or XML response body.
+ * @param {string|object} source Either a parser key or full source definition.
+ * @returns {Array<object>} Parsed tender rows.
  */
-exports.parseTenders = function parseTenders(html, site = 'contractsFinder') {
-  switch (site) {
+exports.parseTenders = function parseTenders(html, source = 'contractsFinder') {
+  const sourceConfig =
+    typeof source === 'string' || !source
+      ? { parser: source || 'contractsFinder' }
+      : source;
+
+  if (sourceConfig && sourceConfig.selectors) {
+    return parseGeneric(html, sourceConfig.selectors);
+  }
+
+  const parserKey = sourceConfig && sourceConfig.parser ? sourceConfig.parser : 'contractsFinder';
+
+  switch (parserKey) {
     case 'eusupply':
       return parseEuSupply(html);
     case 'sell2wales':

--- a/server/index.js
+++ b/server/index.js
@@ -126,11 +126,20 @@ function openBrowser(url) {
     // Load any persisted sources and merge them into the config object.
     const rows = await db.getSources();
     for (const row of rows) {
+      let selectors;
+      if (row.selectors) {
+        try {
+          selectors = JSON.parse(row.selectors);
+        } catch (err) {
+          logger.warn(`Failed to parse selectors for source ${row.key}:`, err);
+        }
+      }
       config.sources[row.key] = {
         label: row.label,
         url: row.url,
         base: row.base,
-        parser: row.parser
+        parser: row.parser,
+        selectors
       };
     }
 
@@ -138,11 +147,20 @@ function openBrowser(url) {
     // custom entries defined via the admin UI.
     const awardRows = await db.getAwardSources();
     for (const row of awardRows) {
+      let selectors;
+      if (row.selectors) {
+        try {
+          selectors = JSON.parse(row.selectors);
+        } catch (err) {
+          logger.warn(`Failed to parse award selectors for ${row.key}:`, err);
+        }
+      }
       config.awardSources[row.key] = {
         label: row.label,
         url: row.url,
         base: row.base,
-        parser: row.parser
+        parser: row.parser,
+        selectors
       };
     }
 
@@ -689,7 +707,7 @@ app.get('/test-source', requireAuth, async (req, res) => {
   try {
     const r = await fetch(src.url);
     const html = await r.text();
-    const tenders = parseTenders(html, src.parser);
+    const tenders = parseTenders(html, src);
     sourceStatus[key] = 'ok';
     res.json({ status: 'ok', count: tenders.length });
   } catch (err) {
@@ -706,7 +724,7 @@ app.get('/test-award-source', requireAuth, async (req, res) => {
   try {
     const r = await fetch(src.url);
     const html = await r.text();
-    const tenders = parseTenders(html, src.parser);
+    const tenders = parseTenders(html, src);
     sourceStatus[key] = 'ok';
     res.json({ status: 'ok', count: tenders.length });
   } catch (err) {

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -68,12 +68,14 @@ async function runInternal(onProgress, sourceKey, source) {
     // Determine the URL/base for this run. When no source is supplied we
     // construct an object using the default Contracts Finder settings and the
     // parser key expected by htmlParser.
+    const defaultSource = config.sources?.default || {};
     const src =
       source || {
         url: config.scrapeUrl,
         base: config.scrapeBase,
         parser: 'contractsFinder',
-        label: 'Contracts Finder'
+        label: defaultSource.label || 'Contracts Finder',
+        selectors: defaultSource.selectors
       };
 
     // Track how long the scrape takes so progress messages can include the
@@ -122,7 +124,7 @@ async function runInternal(onProgress, sourceKey, source) {
 
       // Extract tenders from the HTML using the configured parser and add them
       // to the overall results list.
-      const pageTenders = parseTenders(html, src.parser);
+      const pageTenders = parseTenders(html, src);
       logger.info(`Found ${pageTenders.length} tenders on ${src.label} page ${page}`);
       allTenders.push(...pageTenders);
 

--- a/server/scrapeAwarded.js
+++ b/server/scrapeAwarded.js
@@ -65,12 +65,14 @@ async function runInternal(onProgress, sourceKey, source) {
     // Determine the URL/base for this run. When no source is supplied we
     // construct an object using the default Contracts Finder settings and the
     // parser key expected by htmlParser.
+    const defaultAward = config.awardSources?.default || {};
     const src =
       source || {
-        url: config.awardSources.default.url,
-        base: config.awardSources.default.base,
-        parser: config.awardSources.default.parser || 'contractsFinder',
-        label: config.awardSources.default.label || 'Contracts Finder Awards'
+        url: defaultAward.url,
+        base: defaultAward.base,
+        parser: defaultAward.parser || 'contractsFinder',
+        label: defaultAward.label || 'Contracts Finder Awards',
+        selectors: defaultAward.selectors
       };
 
     // Log the start of the scrape and let any progress listener know which
@@ -103,7 +105,7 @@ async function runInternal(onProgress, sourceKey, source) {
 
       // Extract tenders from the HTML using the configured parser and add them
       // to the overall results list.
-      const pageTenders = parseTenders(html, src.parser);
+      const pageTenders = parseTenders(html, src);
       logger.info(`Found ${pageTenders.length} tenders on ${src.label} page ${page}`);
       allTenders.push(...pageTenders);
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -63,4 +63,33 @@ describe('htmlParser', () => {
     expect(tenders[0].link).to.equal('/u1');
     expect(tenders[1].date).to.equal('2024-04-04');
   });
+
+  it('parses tenders using generic selectors when provided', () => {
+    const html = `
+      <section class="list">
+        <article data-ocid="ocds-x">
+          <a class="opportunity" href="/g1">Generic 1</a>
+          <time>2024-05-01</time>
+          <p class="summary">Desc G1</p>
+        </article>
+        <article>
+          <a class="opportunity" href="/g2">Generic 2</a>
+          <span class="posted">2024-05-02</span>
+          <div class="summary">Desc G2</div>
+        </article>
+      </section>`;
+    const selectors = {
+      item: 'article',
+      title: '.opportunity',
+      link: { selector: '.opportunity', attr: 'href' },
+      date: ['time', '.posted'],
+      description: '.summary'
+    };
+    const tenders = parseTenders(html, { selectors });
+    expect(tenders).to.have.length(2);
+    expect(tenders[0].title).to.equal('Generic 1');
+    expect(tenders[0].ocid).to.equal('ocds-x');
+    expect(tenders[1].date).to.equal('2024-05-02');
+    expect(tenders[1].desc).to.equal('Desc G2');
+  });
 });


### PR DESCRIPTION
## Summary
- add a generic CSS selector driven parser and dispatch logic to use it whenever a source provides selectors
- extend the configuration and scraper plumbing so sources can ship selectors (with EU Supply now described via CSS selectors)
- cover the new behaviour with parser unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca739ba5548328bb354390cd111907