### PR TITLE
Improve scraper pagination handling

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,4 +1,87 @@
+/**
+ * @file config.js
+ * @description Centralised configuration shared across the server, scrapers
+ * and background jobs. Values are derived from environment variables where
+ * available and fall back to sensible defaults for local development. The
+ * module intentionally exposes scraper pagination settings so individual
+ * sources can override behaviour without code changes.
+ */
 const path = require('path');
+
+/**
+ * Parse a comma-separated environment variable into an array of CSS selectors.
+ * Empty values are discarded and the list is cloned to avoid accidental
+ * mutation when the configuration is consumed elsewhere.
+ *
+ * @param {string|string[]} value - Value taken from the environment or config
+ * @param {string[]} fallback - Default selectors when no value is provided
+ * @returns {string[]} normalised selector list
+ */
+function parseSelectorList(value, fallback = []) {
+  if (Array.isArray(value) && value.length > 0) {
+    return value.map(selector => selector.trim()).filter(Boolean);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return value
+      .split(',')
+      .map(selector => selector.trim())
+      .filter(Boolean);
+  }
+  return [...fallback];
+}
+
+/**
+ * Convert an environment string into a positive integer, falling back to a
+ * default when parsing fails or the provided value is out of range.
+ *
+ * @param {string|number|undefined} value - User supplied value to parse
+ * @param {number} fallback - Default integer to use when parsing fails
+ * @returns {number} a positive integer suitable for pagination limits
+ */
+function parsePositiveInt(value, fallback) {
+  const num = Number.parseInt(value, 10);
+  if (Number.isNaN(num) || num <= 0) {
+    return fallback;
+  }
+  return num;
+}
+
+const DEFAULT_NAV_SELECTORS = [
+  'nav[role="navigation"]',
+  'nav.pagination',
+  '.pagination',
+  'ul.pagination',
+  'ol.pagination',
+  '.pager',
+  '.paging'
+];
+
+const DEFAULT_NEXT_LINK_SELECTORS = [
+  'a[rel="next"]',
+  'link[rel="next"]',
+  'a[aria-label*="next" i]',
+  'a[title*="next" i]',
+  'a.next',
+  'li.next a',
+  '.next a'
+];
+
+// Standard pagination configuration applied to every source unless overridden.
+// Exposed so individual sources can tweak selector lists or page limits.
+const defaultPagination = {
+  maxPages: parsePositiveInt(process.env.PAGINATION_MAX_PAGES, 25),
+  navSelectors: parseSelectorList(
+    process.env.PAGINATION_NAV_SELECTORS,
+    DEFAULT_NAV_SELECTORS
+  ),
+  nextLinkSelectors: parseSelectorList(
+    process.env.PAGINATION_NEXT_SELECTORS,
+    DEFAULT_NEXT_LINK_SELECTORS
+  ),
+  pageNumberPattern:
+    (process.env.PAGINATION_PAGE_NUMBER_PATTERN || '\\d+').trim() || '\\d+',
+  detectLoops: process.env.PAGINATION_DETECT_LOOPS === 'false' ? false : true
+};
 
 // Centralised configuration object used throughout the server code. Values can
 // be overridden via environment variables for flexibility in different
@@ -15,7 +98,8 @@ const defaultSource = {
   base:
     process.env.SCRAPE_BASE ||
     'https://www.contractsfinder.service.gov.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 // Other sources previously included here have been removed as they either no
@@ -41,7 +125,8 @@ const euSupplySource = {
     link: { selector: 'a', attr: 'href' },
     date: ['time', 'td:nth-child(3)'],
     description: ['td.description', 'p']
-  }
+  },
+  pagination: { ...defaultPagination }
 };
 
 // Example Sell2Wales source used by the additional `sell2wales` parser.
@@ -52,7 +137,8 @@ const sell2walesSource = {
     process.env.SELL2WALES_URL ||
     'https://www.sell2wales.gov.wales/rss/authority',
   base: process.env.SELL2WALES_BASE || 'https://www.sell2wales.gov.wales',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 // Example UKRI opportunities source.
@@ -61,7 +147,8 @@ const ukriSource = {
   // Opportunities feed published by UKRI.
   url: process.env.UKRI_URL || 'https://www.ukri.org/feed/',
   base: process.env.UKRI_BASE || 'https://www.ukri.org',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 // Additional procurement portals that expose RSS feeds. These are included as
@@ -72,7 +159,8 @@ const pcsSource = {
     process.env.PCS_URL ||
     'https://www.publiccontractsscotland.gov.uk/rss/rss.xml',
   base: process.env.PCS_BASE || 'https://www.publiccontractsscotland.gov.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const etendersniSource = {
@@ -81,7 +169,8 @@ const etendersniSource = {
     process.env.ETENDERSNI_URL ||
     'https://etendersni.gov.uk/epps/cft/list?ext_t=RSS',
   base: process.env.ETENDERSNI_BASE || 'https://etendersni.gov.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const etendersIEsource = {
@@ -90,7 +179,8 @@ const etendersIEsource = {
     process.env.ETENDERSIE_URL ||
     'https://www.etenders.gov.ie/feeds/rss',
   base: process.env.ETENDERSIE_BASE || 'https://www.etenders.gov.ie',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const procontractSource = {
@@ -99,14 +189,16 @@ const procontractSource = {
     process.env.PROCONTRACT_URL ||
     'https://procontract.due-north.com/rss/rss.xml',
   base: process.env.PROCONTRACT_BASE || 'https://procontract.due-north.com',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const intendSource = {
   label: 'In-Tend',
   url: process.env.INTEND_URL || 'https://in-tendhost.co.uk/feed/',
   base: process.env.INTEND_BASE || 'https://in-tendhost.co.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 // Sources providing information on awarded contracts. These mirror the
@@ -121,7 +213,8 @@ const defaultAwardSource = {
   base:
     process.env.AWARD_BASE ||
     'https://www.contractsfinder.service.gov.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const euSupplyAwardSource = {
@@ -130,7 +223,8 @@ const euSupplyAwardSource = {
     process.env.EUSUPPLY_AWARD_URL ||
     'https://uk.eu-supply.com/ctm/award/publiccontracts?B=UK',
   base: process.env.EUSUPPLY_AWARD_BASE || 'https://uk.eu-supply.com',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const sell2walesAwardSource = {
@@ -139,14 +233,16 @@ const sell2walesAwardSource = {
     process.env.SELL2WALES_AWARD_URL ||
     'https://www.sell2wales.gov.wales/rss/award',
   base: process.env.SELL2WALES_AWARD_BASE || 'https://www.sell2wales.gov.wales',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const ukriAwardSource = {
   label: 'UKRI Awards',
   url: process.env.UKRI_AWARD_URL || 'https://www.ukri.org/awards/feed/',
   base: process.env.UKRI_AWARD_BASE || 'https://www.ukri.org',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const pcsAwardSource = {
@@ -156,7 +252,8 @@ const pcsAwardSource = {
     'https://www.publiccontractsscotland.gov.uk/rss/award.xml',
   base:
     process.env.PCS_AWARD_BASE || 'https://www.publiccontractsscotland.gov.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const etendersniAwardSource = {
@@ -165,7 +262,8 @@ const etendersniAwardSource = {
     process.env.ETENDERSNI_AWARD_URL ||
     'https://etendersni.gov.uk/epps/cft/listAward?ext_t=RSS',
   base: process.env.ETENDERSNI_AWARD_BASE || 'https://etendersni.gov.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const etendersieAwardSource = {
@@ -174,7 +272,8 @@ const etendersieAwardSource = {
     process.env.ETENDERSIE_AWARD_URL ||
     'https://www.etenders.gov.ie/feeds/award',
   base: process.env.ETENDERSIE_AWARD_BASE || 'https://www.etenders.gov.ie',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const procontractAwardSource = {
@@ -183,7 +282,8 @@ const procontractAwardSource = {
     process.env.PROCONTRACT_AWARD_URL ||
     'https://procontract.due-north.com/rss/award.xml',
   base: process.env.PROCONTRACT_AWARD_BASE || 'https://procontract.due-north.com',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const intendAwardSource = {
@@ -191,14 +291,16 @@ const intendAwardSource = {
   url:
     process.env.INTEND_AWARD_URL || 'https://in-tendhost.co.uk/awards/feed/',
   base: process.env.INTEND_AWARD_BASE || 'https://in-tendhost.co.uk',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 const tedAwardSource = {
   label: 'TED Europa',
   url: process.env.TED_AWARD_URL || 'https://ted.europa.eu/udl?uri=TED/rss/awards',
   base: process.env.TED_AWARD_BASE || 'https://ted.europa.eu',
-  parser: 'rss'
+  parser: 'rss',
+  pagination: { ...defaultPagination }
 };
 
 // Default tagging rules used when none are supplied via the TAG_RULES
@@ -254,14 +356,17 @@ module.exports = {
     ted: tedAwardSource
   },
 
+  // Global pagination defaults used by the scraping helpers. Individual
+  // sources can override specific properties via their `pagination` field.
+  pagination: defaultPagination,
+
   // Legacy fields maintained for backwards compatibility. These map to the
   // default source so existing code and tests continue to work.
   scrapeUrl: defaultSource.url,
   scrapeBase: defaultSource.base,
 
   // Cron expression determining when the scraper runs automatically
-  cronSchedule: process.env.CRON_SCHEDULE || '0 6 * * *'
-  ,
+  cronSchedule: process.env.CRON_SCHEDULE || '0 6 * * *',
   // Keyword rules for automatic tagging. The value can be overridden by
   // setting the TAG_RULES environment variable to a JSON string matching the
   // shape of `defaultTagRules` above.

--- a/server/pagination.js
+++ b/server/pagination.js
@@ -1,0 +1,283 @@
+/**
+ * @file pagination.js
+ * @description Helper utilities shared by the tender and award scrapers for
+ * handling paginated result sets. The helpers merge source specific overrides
+ * with global defaults, identify suitable "next page" links using Cheerio and
+ * enforce safety limits such as maximum page counts and loop detection.
+ */
+const config = require('./config');
+
+/**
+ * Normalise a selector list into a clean array of CSS selectors. Strings are
+ * split on commas to make environment configuration ergonomic.
+ *
+ * @param {string|string[]} value - Raw selector configuration
+ * @param {string[]} [fallback=[]] - Fallback list when no selectors are given
+ * @returns {string[]} Sanitised selector array
+ */
+function normaliseSelectorList(value, fallback = []) {
+  if (Array.isArray(value) && value.length > 0) {
+    return value.map(selector => selector.trim()).filter(Boolean);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return value
+      .split(',')
+      .map(selector => selector.trim())
+      .filter(Boolean);
+  }
+  return [...fallback];
+}
+
+/**
+ * Parse a value into a positive integer, returning the fallback when parsing
+ * fails or the result is less than one.
+ *
+ * @param {number|string|undefined} value - Value provided by configuration
+ * @param {number} fallback - Default to use when parsing fails
+ * @returns {number} Positive integer suitable for pagination limits
+ */
+function parsePositiveInt(value, fallback) {
+  const num = Number.parseInt(value, 10);
+  if (Number.isNaN(num) || num <= 0) {
+    return fallback;
+  }
+  return num;
+}
+
+/**
+ * Merge pagination settings defined globally in config.js with optional
+ * per-source overrides. The result is a fully populated configuration object
+ * that downstream scraping logic can rely on without needing to constantly
+ * guard against missing values.
+ *
+ * @param {object} [source={}] - Source configuration containing optional overrides
+ * @returns {{maxPages:number, navSelectors:string[], nextLinkSelectors:string[], pageNumberPattern:string, detectLoops:boolean}}
+ */
+function resolvePaginationConfig(source = {}) {
+  const defaults = config.pagination || {};
+  const overrides = source.pagination || {};
+
+  const baseMaxPages = parsePositiveInt(defaults.maxPages, 25);
+  const maxPages = parsePositiveInt(overrides.maxPages, baseMaxPages);
+
+  const defaultNavSelectors = normaliseSelectorList(defaults.navSelectors);
+  const defaultNextSelectors = normaliseSelectorList(defaults.nextLinkSelectors);
+
+  const navSelectors = normaliseSelectorList(
+    overrides.navSelectors,
+    defaultNavSelectors
+  );
+  const nextLinkSelectors = normaliseSelectorList(
+    overrides.nextLinkSelectors,
+    defaultNextSelectors
+  );
+
+  const pageNumberPattern =
+    typeof overrides.pageNumberPattern === 'string' && overrides.pageNumberPattern.trim()
+      ? overrides.pageNumberPattern.trim()
+      : typeof defaults.pageNumberPattern === 'string' && defaults.pageNumberPattern.trim()
+      ? defaults.pageNumberPattern.trim()
+      : '\\d+';
+
+  const detectLoops =
+    overrides.detectLoops !== undefined
+      ? Boolean(overrides.detectLoops)
+      : defaults.detectLoops !== undefined
+      ? Boolean(defaults.detectLoops)
+      : true;
+
+  return {
+    maxPages,
+    navSelectors,
+    nextLinkSelectors,
+    pageNumberPattern,
+    detectLoops
+  };
+}
+
+/**
+ * Convert a possibly relative pagination href into an absolute URL. The helper
+ * gracefully handles placeholders such as "#" or "javascript:void(0)" by
+ * returning null which signals the caller to skip the link.
+ *
+ * @param {string|undefined|null} rawHref - Raw href attribute from the DOM
+ * @param {string} baseUrl - Base URL used to resolve relative links
+ * @returns {string|null} Absolute URL or null when the href is unusable
+ */
+function resolveAbsoluteUrl(rawHref, baseUrl) {
+  if (!rawHref) {
+    return null;
+  }
+  const trimmed = rawHref.trim();
+  if (!trimmed || trimmed === '#' || trimmed.toLowerCase().startsWith('javascript')) {
+    return null;
+  }
+  try {
+    const normalised = trimmed.replace(/&amp;/gi, '&');
+    return new URL(normalised, baseUrl).href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compile the configured page number regex, falling back to a simple digit
+ * matcher whenever the pattern is invalid. Invalid patterns are logged so
+ * administrators can diagnose misconfiguration quickly.
+ *
+ * @param {string} pattern - Regex pattern provided by configuration
+ * @param {{info:Function}} [logger] - Optional logger for diagnostics
+ * @returns {RegExp} Compiled regular expression
+ */
+function compilePageNumberRegex(pattern, logger) {
+  try {
+    return new RegExp(pattern, 'i');
+  } catch (err) {
+    if (logger && typeof logger.info === 'function') {
+      logger.info(
+        `Invalid pageNumberPattern "${pattern}" supplied; defaulting to /\\d+/`
+      );
+    }
+    return /\d+/i;
+  }
+}
+
+/**
+ * Inspect the provided Cheerio document and identify the most suitable URL for
+ * the next page of results. Preference is given to rel="next" links, anchors
+ * whose text explicitly contains "Next" or arrow glyphs and finally numerical
+ * links representing page numbers. URLs already visited are skipped to prevent
+ * loops.
+ *
+ * @param {import('cheerio').CheerioAPI} $ - Cheerio instance for the page
+ * @param {string} baseUrl - Base URL used to resolve relative links
+ * @param {object} paginationConfig - Output of resolvePaginationConfig()
+ * @param {Set<string>} visitedUrls - URLs already requested during this run
+ * @param {number} currentPage - One-based index of the current page
+ * @param {{info:Function}} [logger] - Optional logger for diagnostics
+ * @returns {string|null} Absolute URL for the next page or null when none exist
+ */
+function findNextPageUrl(
+  $,
+  baseUrl,
+  paginationConfig,
+  visitedUrls,
+  currentPage,
+  logger
+) {
+  const seen = visitedUrls || new Set();
+
+  const firstMatching = selector => {
+    if (!selector) {
+      return null;
+    }
+    const nodes = $(selector).toArray();
+    for (const node of nodes) {
+      const href = resolveAbsoluteUrl($(node).attr('href'), baseUrl);
+      if (href && !seen.has(href)) {
+        return href;
+      }
+    }
+    return null;
+  };
+
+  for (const selector of paginationConfig.nextLinkSelectors || []) {
+    const candidate = firstMatching(selector);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  const navElements = [];
+  for (const selector of paginationConfig.navSelectors || []) {
+    if (!selector) {
+      continue;
+    }
+    const matches = $(selector).toArray();
+    if (matches.length) {
+      navElements.push(...matches);
+    }
+  }
+
+  if (navElements.length === 0) {
+    return null;
+  }
+
+  const pageNumberRegex = compilePageNumberRegex(
+    paginationConfig.pageNumberPattern,
+    logger
+  );
+
+  let exactNextHref = null;
+  let labelledNextHref = null;
+  let smallestGreater = null;
+  let fallbackHref = null;
+
+  const considerAnchor = element => {
+    const anchor = $(element);
+    const href = resolveAbsoluteUrl(anchor.attr('href'), baseUrl);
+    if (!href || seen.has(href)) {
+      return;
+    }
+
+    if (!fallbackHref) {
+      fallbackHref = href;
+    }
+
+    const text = anchor.text().replace(/\s+/g, ' ').trim();
+    if (!text) {
+      return;
+    }
+
+    const lower = text.toLowerCase();
+    if (!labelledNextHref && (lower.includes('next') || /›|»|→/.test(text))) {
+      labelledNextHref = href;
+    }
+
+    const match = text.match(pageNumberRegex);
+    if (!match || match.length === 0) {
+      return;
+    }
+
+    const pageNum = Number.parseInt(match[match.length - 1], 10);
+    if (Number.isNaN(pageNum) || pageNum <= currentPage) {
+      return;
+    }
+
+    if (pageNum === currentPage + 1 && !exactNextHref) {
+      exactNextHref = href;
+      return;
+    }
+
+    if (!smallestGreater || pageNum < smallestGreater.pageNum) {
+      smallestGreater = { href, pageNum };
+    }
+  };
+
+  for (const navElement of navElements) {
+    if (navElement && navElement.name === 'a') {
+      considerAnchor(navElement);
+    }
+    $(navElement)
+      .find('a[href]')
+      .each((_, anchorEl) => {
+        considerAnchor(anchorEl);
+      });
+  }
+
+  if (exactNextHref) {
+    return exactNextHref;
+  }
+  if (labelledNextHref) {
+    return labelledNextHref;
+  }
+  if (smallestGreater) {
+    return smallestGreater.href;
+  }
+  return fallbackHref;
+}
+
+module.exports = {
+  resolvePaginationConfig,
+  findNextPageUrl
+};

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -7,12 +7,14 @@
  * source. Extensive logging and progress callbacks aid debugging.
  */
 const fetch = require('node-fetch');
+const cheerio = require('cheerio');
 const { parseTenders } = require('./htmlParser');
 // Detail pages expose additional metadata such as CPV classifications.
 const { parseTenderDetails } = require('./detailParser');
 const db = require('./db');
 const config = require('./config');
 const logger = require('./logger');
+const { resolvePaginationConfig, findNextPageUrl } = require('./pagination');
 
 // Network safety limits: abort requests taking longer than 10s and cap response
 // bodies at 5MB to avoid resource exhaustion.
@@ -75,7 +77,8 @@ async function runInternal(onProgress, sourceKey, source) {
         base: config.scrapeBase,
         parser: 'contractsFinder',
         label: defaultSource.label || 'Contracts Finder',
-        selectors: defaultSource.selectors
+        selectors: defaultSource.selectors,
+        pagination: defaultSource.pagination || config.pagination
       };
 
     // Track how long the scrape takes so progress messages can include the
@@ -89,19 +92,35 @@ async function runInternal(onProgress, sourceKey, source) {
       onProgress({ step: 'start', source: src, elapsed: 0 });
     }
 
-    // Collect tenders from all available pages. Some sources only show a
-    // limited number of results per page so we follow any "next" links until
-    // no further pages remain. This keeps the implementation generic without
-    // hard coding page query parameters.
+    // Collect tenders from all available pages. The pagination helper inspects
+    // HTML navigation elements to find the next link while guarding against
+    // loops or excessive page counts.
     const allTenders = [];
     let nextUrl = src.url;
     let page = 1;
+    const pagination = resolvePaginationConfig(src);
+    const pageLimit = Math.max(1, pagination.maxPages || 1);
+    const visitedUrls = new Set();
     const headers = {
       'User-Agent':
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36'
     };
 
     while (nextUrl) {
+      if (pagination.detectLoops && visitedUrls.has(nextUrl)) {
+        logger.info(
+          `Detected repeated pagination URL on ${src.label}; stopping at ${nextUrl}`
+        );
+        break;
+      }
+      if (page > pageLimit) {
+        logger.info(
+          `Reached pagination limit (${pageLimit}) for ${src.label}; halting further requests`
+        );
+        break;
+      }
+      visitedUrls.add(nextUrl);
+
       // Notify listeners which page is about to be fetched along with the
       // number of seconds elapsed since the run started. This provides visible
       // feedback that progress is being made even when a single page takes a
@@ -121,6 +140,7 @@ async function runInternal(onProgress, sourceKey, source) {
         size: MAX_RESPONSE_SIZE
       });
       const html = await res.text();
+      const $ = cheerio.load(html);
 
       // Extract tenders from the HTML using the configured parser and add them
       // to the overall results list.
@@ -128,49 +148,26 @@ async function runInternal(onProgress, sourceKey, source) {
       logger.info(`Found ${pageTenders.length} tenders on ${src.label} page ${page}`);
       allTenders.push(...pageTenders);
 
-      // Stop following pagination if the current page contains no tenders.
-      // This prevents unnecessary requests when the "next" link points to a
-      // placeholder page beyond the available results.
       if (pageTenders.length === 0) {
+        logger.info(`No tenders detected on ${src.label} page ${page}; stopping pagination.`);
         break;
       }
 
-      // Look for a link pointing to the next page. Many sites mark this with a
-      // rel="next" attribute, add a class containing "next" or include the word
-      // "Next" in the link text. Relative URLs are resolved against the source
-      // base URL so both absolute and relative links are handled consistently.
-      const relNext = html.match(/<link[^>]*rel=["']?next["']?[^>]*href=["']([^"']+)["']/i);
-      // Try to detect links that include "next" in a rel, class or aria-label
-      // attribute so we cover common pagination patterns.
-      const attrNext = html.match(
-        /<a[^>]*(?:rel|class|aria-label)=["'][^"']*next[^"']*["'][^>]*href=["']([^"']+)["']/i
+      const nextPageUrl = findNextPageUrl(
+        $,
+        src.base || nextUrl,
+        pagination,
+        visitedUrls,
+        page,
+        logger
       );
-      // Fallback to matching the visible link text when attributes are not
-      // present or use different naming.
-      const textNext = html.match(
-        /<a[^>]*href=["']([^"']+)["'][^>]*>(?:\s*Next\s*|›|&gt;|&raquo;)/i
-      );
-      const href = relNext
-        ? relNext[1]
-        : attrNext
-        ? attrNext[1]
-        : textNext
-        ? textNext[1]
-        : null;
-      // Some sites include a disabled "next" link with a placeholder href such
-      // as "#" or "javascript:void(0)". Following these would cause the scraper
-      // to loop indefinitely, so ignore them when detected.
-      const cleanHref = href && href.replace(/&amp;/g, '&');
-      if (
-        cleanHref &&
-        cleanHref !== '#' &&
-        !cleanHref.toLowerCase().startsWith('javascript')
-      ) {
-        nextUrl = new URL(cleanHref, src.base).href;
+      if (nextPageUrl) {
+        nextUrl = nextPageUrl;
+        page += 1;
       } else {
+        logger.info(`No further pagination link found on ${src.label} page ${page}.`);
         nextUrl = null;
       }
-      page += 1;
     }
 
     logger.info(`Found ${allTenders.length} tenders on ${src.label}`);

--- a/server/scrapeAwarded.js
+++ b/server/scrapeAwarded.js
@@ -6,11 +6,13 @@
  * a single source and `runAll` for iterating over every configured award feed.
  */
 const fetch = require('node-fetch');
+const cheerio = require('cheerio');
 const { parseTenders } = require('./htmlParser');
 const { parseAwardDetails } = require('./detailParser');
 const db = require('./db');
 const config = require('./config');
 const logger = require('./logger');
+const { resolvePaginationConfig, findNextPageUrl } = require('./pagination');
 
 // Enforce network limits to defend against slow or extremely large responses.
 const FETCH_TIMEOUT = 10000; // ms
@@ -72,7 +74,8 @@ async function runInternal(onProgress, sourceKey, source) {
         base: defaultAward.base,
         parser: defaultAward.parser || 'contractsFinder',
         label: defaultAward.label || 'Contracts Finder Awards',
-        selectors: defaultAward.selectors
+        selectors: defaultAward.selectors,
+        pagination: defaultAward.pagination || config.pagination
       };
 
     // Log the start of the scrape and let any progress listener know which
@@ -82,19 +85,34 @@ async function runInternal(onProgress, sourceKey, source) {
       onProgress({ step: 'start', source: src });
     }
 
-    // Collect tenders from all available pages. Some sources only show a
-    // limited number of results per page so we follow any "next" links until
-    // no further pages remain. This keeps the implementation generic without
-    // hard coding page query parameters.
+    // Collect tenders from all available pages using the shared pagination
+    // helper to avoid loops and respect configurable page caps.
     const allTenders = [];
     let nextUrl = src.url;
     let page = 1;
+    const pagination = resolvePaginationConfig(src);
+    const pageLimit = Math.max(1, pagination.maxPages || 1);
+    const visitedUrls = new Set();
     const headers = {
       'User-Agent':
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36'
     };
 
     while (nextUrl) {
+      if (pagination.detectLoops && visitedUrls.has(nextUrl)) {
+        logger.info(
+          `Detected repeated pagination URL on ${src.label}; stopping at ${nextUrl}`
+        );
+        break;
+      }
+      if (page > pageLimit) {
+        logger.info(
+          `Reached pagination limit (${pageLimit}) for ${src.label}; halting further requests`
+        );
+        break;
+      }
+      visitedUrls.add(nextUrl);
+
       // Fetch each page sequentially using a browser-like User-Agent.
       const res = await fetch(nextUrl, {
         headers,
@@ -102,6 +120,7 @@ async function runInternal(onProgress, sourceKey, source) {
         size: MAX_RESPONSE_SIZE
       });
       const html = await res.text();
+      const $ = cheerio.load(html);
 
       // Extract tenders from the HTML using the configured parser and add them
       // to the overall results list.
@@ -109,16 +128,26 @@ async function runInternal(onProgress, sourceKey, source) {
       logger.info(`Found ${pageTenders.length} tenders on ${src.label} page ${page}`);
       allTenders.push(...pageTenders);
 
-      // Look for a link pointing to the next page. Many sites mark this with a
-      // rel="next" attribute or anchor text containing "Next". Relative URLs are
-      // resolved against the source base URL so both absolute and relative links
-      // are handled consistently.
-      const relNext = html.match(/<link[^>]*rel=["']next["'][^>]*href=["']([^"']+)["']/i);
-      const anchorNext =
-        html.match(/<a[^>]*href=["']([^"']+)["'][^>]*>(?:Next|next|›|&gt;|&raquo;)/i);
-      const href = relNext ? relNext[1] : anchorNext ? anchorNext[1] : null;
-      nextUrl = href ? new URL(href.replace(/&amp;/g, '&'), src.base).href : null;
-      page += 1;
+      if (pageTenders.length === 0) {
+        logger.info(`No tenders detected on ${src.label} page ${page}; stopping pagination.`);
+        break;
+      }
+
+      const nextPageUrl = findNextPageUrl(
+        $,
+        src.base || nextUrl,
+        pagination,
+        visitedUrls,
+        page,
+        logger
+      );
+      if (nextPageUrl) {
+        nextUrl = nextPageUrl;
+        page += 1;
+      } else {
+        logger.info(`No further pagination link found on ${src.label} page ${page}.`);
+        nextUrl = null;
+      }
     }
 
     logger.info(`Found ${allTenders.length} tenders on ${src.label}`);


### PR DESCRIPTION
## Summary
- expose configurable pagination defaults and per-source overrides in `server/config.js`
- add a shared pagination utility that parses HTML with Cheerio to resolve next-page links while avoiding loops
- update tender and award scrapers to honour the new pagination settings, enforce page limits and stop on repeated URLs

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cac06913c88328a1c8801556adb621