### PR TITLE
Improve HTTP retry failure logging

### DIFF
--- a/server/httpClient.js
+++ b/server/httpClient.js
@@ -60,10 +60,14 @@ client.interceptors.response.use(
 
     if (attempts >= allowed) {
       const url = requestConfig.url || 'unknown URL';
+      const totalAttempts = attempts + 1; // include the initial request attempt
+      const status = error.response?.status;
+      const statusSegment =
+        typeof status === 'number' ? ` with status ${status}` : '';
       logger.error(
-        `Request to ${url} failed after ${attempts} attempt${
-          attempts === 1 ? '' : 's'
-        }: ${error.message}`
+        `Request to ${url} failed after ${totalAttempts} attempt${
+          totalAttempts === 1 ? '' : 's'
+        }${statusSegment}: ${error.message}`
       );
     }
 


### PR DESCRIPTION
## Summary
- confirm that the tender scrapers already call the shared axios-based helper with concurrency-limited detail fetching
- extend the HTTP client's terminal failure log so it reports the total number of attempts (including the initial try) and any HTTP status for clearer diagnostics

## Testing
- npm test *(fails: environment lacks axios in node_modules and registry access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cadf2339488328a3b59d53dc991c67