### PR TITLE
Persist tender raw payloads and expose modal viewer

### DIFF
--- a/frontend/opportunities.ejs
+++ b/frontend/opportunities.ejs
@@ -1,3 +1,14 @@
+<!--
+  File: opportunities.ejs
+  Overview: Renders the Opportunities dashboard table and associated tooling.
+  Structure:
+    - Navigation header followed by user guidance.
+    - Paginated tender table with per-row detail toggle and raw data controls.
+    - Hidden modal used to display stored raw payloads on demand.
+  Behaviour:
+    - table-tools.js enhances sorting/filtering while local script fetches raw JSON
+      for each tender when requested via the "View Raw" buttons.
+-->
 <!DOCTYPE html>
 <html>
 <head>
@@ -7,6 +18,14 @@
 <body>
   <h1>Opportunities</h1>
   <%- include('partials/nav', { page: 'opportunities', user: user }) %>
+  <div id="instructions">
+    <strong>Quick tips:</strong>
+    <ul>
+      <li>Use the column filters to locate tenders quickly. Results update instantly.</li>
+      <li>Click <em>View Raw</em> for any tender to inspect the exact data captured during scraping.</li>
+      <li>Double click a row to jump into edit modes where available.</li>
+    </ul>
+  </div>
   <!-- data-server-pagination tells table-tools.js that navigation is handled
        by the server so client side pagination should be disabled -->
   <table data-server-pagination="true">
@@ -19,6 +38,7 @@
       <th data-type="date">Scraped At</th>
       <th>Tags</th>
       <th>Link</th>
+      <th>Raw Info</th>
     </tr>
     <% tenders.forEach(t => { %>
       <!-- Each result row can be clicked to reveal a hidden detail row -->
@@ -32,9 +52,10 @@
         <td><%= t.tags %></td>
         <!-- Open tender links in a new tab so the dashboard stays visible -->
         <td><a href="<%= t.link %>" target="_blank">View</a></td>
+        <td><button type="button" class="raw-info-btn" data-id="<%= t.id %>">View Raw</button></td>
       </tr>
       <tr class="detailRow" data-id="<%= t.id %>">
-        <td colspan="7">
+        <td colspan="8">
           <table>
             <tr><th>Title</th><td><%= t.title %></td></tr>
             <tr><th>Date</th><td><%= t.date %></td></tr>
@@ -49,7 +70,7 @@
       </tr>
     <% }) %>
   <% if (tenders.length === 0) { %>
-      <tr><td colspan="7">No opportunities found. Try running the scraper.</td></tr>
+      <tr><td colspan="8">No opportunities found. Try running the scraper.</td></tr>
   <% } %>
   </table>
   <div class="server-pagination">
@@ -62,8 +83,105 @@
       <a href="/opportunities?page=<%= currentPage + 1 %>">Next</a>
     <% } %>
   </div>
+
+  <!-- Modal elements used to present raw JSON payloads -->
+  <div id="rawModalOverlay" class="modal-overlay hidden"></div>
+  <div id="rawModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="rawModalTitle" tabindex="-1">
+    <div class="modal__dialog">
+      <header class="modal__header">
+        <h2 id="rawModalTitle">Raw tender data</h2>
+        <button type="button" id="rawModalClose" class="modal__close" aria-label="Close raw data">&times;</button>
+      </header>
+      <div id="rawModalMeta" class="modal-meta"></div>
+      <div class="modal__body">
+        <pre id="rawModalBody">Select a tender to load its stored payload.</pre>
+      </div>
+    </div>
+  </div>
+
   <!-- Table behaviour such as search, sort and detail toggling is provided -->
   <!-- by table-tools.js so no inline handlers are needed here -->
   <script src="/table-tools.js"></script>
+  <script>
+    (function () {
+      const overlay = document.getElementById('rawModalOverlay');
+      const modal = document.getElementById('rawModal');
+      const modalTitle = document.getElementById('rawModalTitle');
+      const modalMeta = document.getElementById('rawModalMeta');
+      const modalBody = document.getElementById('rawModalBody');
+      const closeBtn = document.getElementById('rawModalClose');
+      if (!overlay || !modal || !modalTitle || !modalBody || !closeBtn) {
+        console.warn('Raw data modal elements are missing from the DOM.');
+        return;
+      }
+
+      function closeModal() {
+        overlay.classList.add('hidden');
+        modal.classList.add('hidden');
+        document.body.classList.remove('modal-open');
+      }
+
+      function openModal(title, message, meta) {
+        modalTitle.textContent = title;
+        modalBody.textContent = message;
+        modalMeta.textContent = meta || '';
+        overlay.classList.remove('hidden');
+        modal.classList.remove('hidden');
+        document.body.classList.add('modal-open');
+        // Focus the close button for accessibility once the modal is visible.
+        setTimeout(() => closeBtn.focus(), 0);
+      }
+
+      closeBtn.addEventListener('click', closeModal);
+      overlay.addEventListener('click', closeModal);
+      document.addEventListener('keydown', evt => {
+        if (evt.key === 'Escape' && !modal.classList.contains('hidden')) {
+          closeModal();
+        }
+      });
+
+      document.querySelectorAll('.raw-info-btn').forEach(btn => {
+        btn.addEventListener('click', async event => {
+          event.stopPropagation();
+          const id = btn.dataset.id;
+          if (!id) {
+            openModal('Raw tender data', 'Unable to determine tender identifier.', '');
+            return;
+          }
+          const row = btn.closest('tr');
+          const fallbackTitle = row && row.children.length ? row.children[0].textContent.trim() : 'Tender';
+          openModal(`Raw data: ${fallbackTitle}`, 'Loading raw payload…', '');
+          try {
+            const response = await fetch(`/opportunities/${encodeURIComponent(id)}/raw`, {
+              headers: { 'Accept': 'application/json' }
+            });
+            if (!response.ok) {
+              throw new Error(`Server returned ${response.status}`);
+            }
+            const payload = await response.json();
+            const displayTitle = payload.title || fallbackTitle;
+            let formatted;
+            if (payload.raw === null || payload.raw === undefined || payload.raw === '') {
+              formatted = 'No raw payload stored for this tender yet.';
+            } else if (typeof payload.raw === 'string') {
+              formatted = payload.raw;
+            } else {
+              formatted = JSON.stringify(payload.raw, null, 2);
+            }
+            modalTitle.textContent = `Raw data: ${displayTitle}`;
+            modalBody.textContent = formatted;
+            const source = payload.source ? `Source: ${payload.source}` : 'Source: Unknown';
+            const scraped = payload.scrapedAt ? `Scraped: ${payload.scrapedAt}` : 'Scraped: Unknown';
+            modalMeta.textContent = `${source} | ${scraped}`;
+          } catch (err) {
+            console.error('Failed to load raw payload', err);
+            modalTitle.textContent = `Raw data: ${fallbackTitle}`;
+            modalBody.textContent = `Unable to load raw data. ${err.message || err}`;
+            modalMeta.textContent = '';
+          }
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,3 +1,13 @@
+/*
+ * File: style.css
+ * Overview: Global stylesheet for the procurement dashboard, covering layout,
+ *   navigation and interactive components used throughout the UI.
+ * Sections:
+ *   1. Base typography and table styling.
+ *   2. Utility components such as instructions, pagination and tabs.
+ *   3. Modal presentation used for raw tender payload viewing.
+ */
+
 /* Base typography and colours */
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -194,6 +204,90 @@ details summary h2 {
 }
 .profile-dropdown li a:hover {
   background: #f1f3f5;
+}
+
+/* Modal overlay and dialog used to present raw tender payloads */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  z-index: 900;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 901;
+}
+
+.modal__dialog {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.25);
+  width: min(900px, 95vw);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.modal__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.modal__close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #6c757d;
+}
+
+.modal__close:hover {
+  color: #000;
+}
+
+.modal-meta {
+  padding: 0 1.25rem 0.75rem;
+  font-size: 0.9rem;
+  color: #495057;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.modal__body {
+  padding: 1.25rem;
+  overflow-y: auto;
+}
+
+.modal__body pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 6px;
+  font-family: "Fira Code", "Source Code Pro", Menlo, monospace;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.modal-open {
+  overflow: hidden;
 }
 /* Utility class toggled via JavaScript */
 .hidden {

--- a/server/db.js
+++ b/server/db.js
@@ -45,7 +45,9 @@ db.serialize(() => {
     customer TEXT,
     address TEXT,
     country TEXT,
-    eligibility TEXT
+    eligibility TEXT,
+    /* Raw JSON payload containing the listing and parsed detail data */
+    raw_details TEXT
   )`);
   // Older installations may lack some of the newer columns. Check the table
   // schema and add any missing columns so inserts do not fail.
@@ -77,7 +79,7 @@ db.serialize(() => {
     } else {
       ensureCpvIndex();
     }
-    ['open_date', 'deadline', 'customer', 'address', 'country', 'eligibility'].forEach(
+    ['open_date', 'deadline', 'customer', 'address', 'country', 'eligibility', 'raw_details'].forEach(
       col => {
         if (!has(col)) {
           addColumn(col);
@@ -217,12 +219,13 @@ module.exports = {
     customer = '',
     address = '',
     country = '',
-    eligibility = ''
+    eligibility = '',
+    rawDetails = ''
   ) => {
     return new Promise((resolve, reject) => {
       db.run(
         // Use INSERT OR IGNORE so that duplicate links or OCIDs are skipped silently.
-        "INSERT OR IGNORE INTO tenders (title, link, ocid, date, description, source, scraped_at, tags, cpv, open_date, deadline, customer, address, country, eligibility) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR IGNORE INTO tenders (title, link, ocid, date, description, source, scraped_at, tags, cpv, open_date, deadline, customer, address, country, eligibility, raw_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         [
           title,
           link,
@@ -238,7 +241,8 @@ module.exports = {
           customer,
           address,
           country,
-          eligibility
+          eligibility,
+          rawDetails
         ],
         function (err) {
           if (err) {
@@ -292,6 +296,28 @@ module.exports = {
             reject(err);
           } else {
             resolve(rows);
+          }
+        }
+      );
+    });
+  },
+
+  /**
+   * Retrieve the stored raw payload for a tender by its identifier.
+   *
+   * @param {number} id - Primary key of the tender row
+   * @returns {Promise<object|null>} resolves with the row or null when missing
+   */
+  getTenderRawById: id => {
+    return new Promise((resolve, reject) => {
+      db.get(
+        'SELECT id, title, source, scraped_at, raw_details FROM tenders WHERE id = ?',
+        [id],
+        (err, row) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(row || null);
           }
         }
       );

--- a/server/index.js
+++ b/server/index.js
@@ -347,6 +347,40 @@ app.get('/opportunities', async (req, res) => {
   });
 });
 
+// GET /opportunities/:id/raw - Provide the stored raw JSON payload for a tender.
+app.get('/opportunities/:id/raw', async (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (!Number.isInteger(id) || id < 1) {
+    return res.status(400).json({ error: 'Invalid tender identifier' });
+  }
+  try {
+    const row = await db.getTenderRawById(id);
+    if (!row) {
+      return res.status(404).json({ error: 'Tender not found' });
+    }
+    let parsed = null;
+    if (row.raw_details) {
+      try {
+        parsed = JSON.parse(row.raw_details);
+      } catch (err) {
+        logger.warn('Raw tender payload could not be parsed as JSON:', err);
+        parsed = row.raw_details;
+      }
+    }
+    res.set('Cache-Control', 'no-store');
+    res.json({
+      id: row.id,
+      title: row.title,
+      source: row.source,
+      scrapedAt: row.scraped_at,
+      raw: parsed
+    });
+  } catch (err) {
+    logger.error('Failed to load raw tender payload:', err);
+    res.status(500).json({ error: 'Unable to load tender payload' });
+  }
+});
+
 // GET /awarded - Display contracts that have been awarded using the separate
 // awards scraper.
 app.get('/awarded', async (req, res) => {

--- a/server/init-db.js
+++ b/server/init-db.js
@@ -1,3 +1,9 @@
+/**
+ * @file init-db.js
+ * @description Helper script to initialise the SQLite database. It mirrors the
+ * runtime schema creation used by the server so that deployments can precreate
+ * tables and load CPV metadata without starting the web application.
+ */
 const sqlite3 = require('sqlite3').verbose();
 const config = require('./config');
 const logger = require('./logger');
@@ -34,7 +40,8 @@ db.serialize(() => {
     customer TEXT,
     address TEXT,
     country TEXT,
-    eligibility TEXT
+    eligibility TEXT,
+    raw_details TEXT
   )`);
   db.run(`CREATE TABLE IF NOT EXISTS awards (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -213,10 +213,10 @@ async function runInternal(onProgress, sourceKey, source) {
               : [])
               .map(code => String(code).trim())
               .filter(Boolean);
-            return { details: parsed, cpvCodes };
+            return { details: parsed, cpvCodes, rawHtml: detailHtml };
           } catch (err) {
             logger.error(`Failed to fetch tender details for ${absoluteLink}:`, err);
-            return { details: {}, cpvCodes: [] };
+            return { details: {}, cpvCodes: [], rawHtml: '' };
           }
         })
       };
@@ -234,15 +234,18 @@ async function runInternal(onProgress, sourceKey, source) {
 
       let details = {};
       let cpvCodes = [];
+      let rawHtml = '';
       if (detailPromise) {
         try {
           const resolved = await detailPromise;
           details = resolved.details || {};
           cpvCodes = resolved.cpvCodes || [];
+          rawHtml = resolved.rawHtml || '';
         } catch (err) {
           logger.error(`Detail processing for ${link} failed:`, err);
           details = {};
           cpvCodes = [];
+          rawHtml = '';
         }
       }
 
@@ -250,6 +253,21 @@ async function runInternal(onProgress, sourceKey, source) {
       // the dashboard can display this context to the user.
       const srcLabel = src.label;
       const scrapedAt = runTs;
+
+      let rawDetailsJson = '';
+      try {
+        rawDetailsJson = JSON.stringify({
+          listing: tender,
+          parsedDetails: details,
+          detailPageHtml: rawHtml,
+          resolvedLink: link,
+          source: srcLabel,
+          scrapedAt: scrapedAt
+        });
+      } catch (err) {
+        logger.error('Failed to serialise raw tender payload:', err);
+        rawDetailsJson = '';
+      }
 
       let inserted = 0;
       try {
@@ -270,7 +288,8 @@ async function runInternal(onProgress, sourceKey, source) {
           details.customer || organisation || '',
           details.address || '',
           details.country || '',
-          details.eligibility || ''
+          details.eligibility || '',
+          rawDetailsJson
         );
 
         if (inserted) {

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -110,6 +110,37 @@ describe('Database helpers', () => {
     expect(rows[0]).to.have.property('open_date');
     expect(rows[0]).to.have.property('deadline');
     expect(rows[0]).to.have.property('customer');
+    expect(rows[0]).to.have.property('raw_details');
+  });
+
+  it('getTenderRawById returns stored payloads', async () => {
+    const rawPayload = JSON.stringify({ sample: true, note: 'raw json' });
+    await db.insertTender(
+      'raw-test',
+      'raw-link',
+      '2024-08-01',
+      'desc',
+      'src',
+      '2024-08-02T00:00:00Z',
+      'tag',
+      'ocds-raw',
+      '33334444',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      rawPayload
+    );
+    const all = await db.getTenders();
+    const row = all.find(r => r.link === 'raw-link');
+    expect(row).to.exist;
+    const stored = await db.getTenderRawById(row.id);
+    expect(stored).to.exist;
+    expect(stored.raw_details).to.equal(rawPayload);
+    const parsed = JSON.parse(stored.raw_details);
+    expect(parsed).to.deep.equal({ sample: true, note: 'raw json' });
   });
 
   it('cron schedule can be stored and retrieved', async () => {


### PR DESCRIPTION
## Summary
- persist raw tender payload JSON by extending the database schema and scraper insert logic
- add an API endpoint plus UI modal so operators can inspect stored payloads from the opportunities table
- style the modal presentation and expand database tests to cover the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6020d3a48328aa88b6c96343a337