### PR TITLE
Fix database tool deletion logic and improve admin UI

### DIFF
--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -20,17 +20,30 @@
     visit the <a href="/help">help page</a> for full instructions.
   </div>
   <!-- Collapsible section listing administrative database actions -->
-  <details id="dbTools">
+  <details id="dbTools" open>
     <summary><h2>Database Tools</h2></summary>
-    <form id="deleteAllForm">
-      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-      <button type="submit">Delete All Records</button>
-    </form>
-    <form id="deleteBeforeForm">
-      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-      <input type="date" id="deleteDate">
-      <button type="submit">Delete Records Before Date</button>
-    </form>
+    <div class="panel-text">
+      <p class="hint">Use these maintenance actions to prune stored tenders.
+        All changes apply immediately, so double-check the selected option before
+        confirming.</p>
+      <div id="dbToolStatus" class="status-banner" role="status" aria-live="polite" hidden>
+        Database status updates will appear here.
+      </div>
+      <div class="db-actions">
+        <form id="deleteAllForm" class="db-action">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <button type="submit" class="danger">Delete All Records</button>
+          <span class="form-hint">Removes every tender from the database.</span>
+        </form>
+        <form id="deleteBeforeForm" class="db-action">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <label for="deleteDate">Delete entries before</label>
+          <input type="date" id="deleteDate" required>
+          <button type="submit" class="danger">Delete Matching Records</button>
+          <span class="form-hint">Useful for archiving tenders older than a specific date.</span>
+        </form>
+      </div>
+    </div>
     <!-- Table populated with counts for each source so administrators can see
          how many tenders are stored and selectively purge them -->
     <h3>Stored Tenders</h3>
@@ -98,8 +111,7 @@
             Base: <span class="base"><%= sources[key].base %></span><br>
             Parser: <span class="parser"><%= sources[key].parser %></span><br>
             <button class="editBtn">Edit</button>
-            <button class="deleteBtn">Delete</button>
-            <button class="deleteBtn">Delete</button>
+            <button class="deleteBtn danger">Delete Source</button>
           </div>
           <div class="editForm" style="display:none">
             <input class="editLabel" value="<%= sources[key].label %>">
@@ -158,7 +170,7 @@
             Base: <span class="base"><%= awardSources[key].base %></span><br>
             Parser: <span class="parser"><%= awardSources[key].parser %></span><br>
             <button class="editBtn">Edit</button>
-            <button class="deleteBtn">Delete</button>
+            <button class="deleteBtn danger">Delete Award Source</button>
           </div>
           <div class="editForm" style="display:none">
             <input class="editLabel" value="<%= awardSources[key].label %>">
@@ -193,6 +205,15 @@ const sourceData = <%= JSON.stringify(sources).replace(/</g, '\u003c') %>;
 const awardSourceData = <%= JSON.stringify(awardSources).replace(/</g, '\u003c') %>;
 let editingKey = null;
 let editingAwardKey = null;
+const statusBanner = document.getElementById('dbToolStatus');
+
+// Present status updates in the banner so administrators do not rely on alerts.
+function announceDbStatus(message, variant = 'info') {
+  if (!statusBanner) return;
+  statusBanner.textContent = message;
+  statusBanner.className = `status-banner ${variant}`;
+  statusBanner.hidden = !message;
+}
 
 // Fetch tender counts from the server and populate the statistics table. Called
 // on page load and after any delete action to keep figures accurate.
@@ -204,7 +225,11 @@ async function loadTenderStats() {
     const res = await fetch('/admin/db-info');
     if (!res.ok) throw new Error('Failed to load');
     const data = await res.json();
-    data.counts.forEach(row => {
+    const counts = Array.isArray(data.counts) ? data.counts : [];
+    if (!counts.length) {
+      announceDbStatus('No tenders are stored in the database yet.', 'info');
+    }
+    counts.forEach(row => {
       const tr = document.createElement('tr');
       const src = document.createElement('td');
       src.textContent = row.source || '(unknown)';
@@ -213,6 +238,7 @@ async function loadTenderStats() {
       const action = document.createElement('td');
       const btn = document.createElement('button');
       btn.textContent = 'Delete';
+      btn.classList.add('danger');
       btn.addEventListener('click', async () => {
         if (!confirm(`Delete all tenders for ${row.source}?`)) return;
         const delRes = await fetch('/admin/delete-source', {
@@ -225,10 +251,22 @@ async function loadTenderStats() {
           body: JSON.stringify({ source: row.source })
         });
         const payload = await delRes.json().catch(() => null);
+        if (delRes.status === 401) {
+          announceDbStatus('Please log in before performing database actions.', 'error');
+          window.location = '/login';
+          return;
+        }
         if (delRes.ok && payload && payload.success) {
+          const removed = payload.removed || 0;
+          const variant = removed > 0 ? 'success' : 'info';
+          const message =
+            removed > 0
+              ? `${removed} tender${removed === 1 ? '' : 's'} removed for ${row.source}.`
+              : `No tenders were removed for ${row.source}.`;
+          announceDbStatus(message, variant);
           loadTenderStats();
         } else {
-          alert('Failed to delete records');
+          announceDbStatus('Failed to delete records for that source.', 'error');
         }
       });
       action.appendChild(btn);
@@ -237,8 +275,25 @@ async function loadTenderStats() {
       tr.appendChild(action);
       table.appendChild(tr);
     });
+    const totalRow = document.createElement('tr');
+    totalRow.className = 'summary-row';
+    const labelCell = document.createElement('td');
+    labelCell.textContent = 'Total stored';
+    const totalCell = document.createElement('td');
+    totalCell.textContent = data.total ?? 0;
+    const spacer = document.createElement('td');
+    spacer.textContent = '';
+    totalRow.append(labelCell, totalCell, spacer);
+    table.appendChild(totalRow);
+    if (counts.length) {
+      announceDbStatus(
+        `Tracking ${data.total ?? 0} tender${(data.total ?? 0) === 1 ? '' : 's'} across ${counts.length} source${counts.length === 1 ? '' : 's'}.`,
+        'success'
+      );
+    }
   } catch (err) {
     console.error('Failed to fetch tender stats', err);
+    announceDbStatus('Unable to load tender statistics. Please try again.', 'error');
   }
 }
 
@@ -444,17 +499,23 @@ document.getElementById('deleteAllForm').addEventListener('submit', async e => {
     method: 'POST',
     headers: { Accept: 'application/json','CSRF-Token': csrfToken }
   });
+  const data = await res.json().catch(() => null);
   if (res.status === 401) {
-    alert('Please log in first');
+    announceDbStatus('Please log in before performing database actions.', 'error');
     window.location = '/login';
     return;
   }
-  const data = await res.json().catch(() => null);
   if (res.ok && data && data.success) {
-    alert('All tenders removed');
+    const removed = data.removed ?? 0;
+    const variant = removed > 0 ? 'success' : 'info';
+    const message =
+      removed > 0
+        ? `${removed} tender${removed === 1 ? '' : 's'} deleted from the database.`
+        : 'No tenders matched the deletion request.';
+    announceDbStatus(message, variant);
     loadTenderStats();
   } else {
-    alert('Failed to delete records');
+    announceDbStatus('Failed to delete records.', 'error');
   }
 });
 
@@ -462,7 +523,10 @@ document.getElementById('deleteAllForm').addEventListener('submit', async e => {
 document.getElementById('deleteBeforeForm').addEventListener('submit', async e => {
   e.preventDefault();
   const date = document.getElementById('deleteDate').value;
-  if (!date) return alert('Select a date first');
+  if (!date) {
+    announceDbStatus('Choose a cutoff date before deleting records.', 'info');
+    return;
+  }
   if (!confirm(`Delete tenders before ${date}?`)) return;
   const res = await fetch('/admin/delete-before', {
     method: 'POST',
@@ -473,17 +537,28 @@ document.getElementById('deleteBeforeForm').addEventListener('submit', async e =
     },
     body: JSON.stringify({ date })
   });
+  const data = await res.json().catch(() => null);
   if (res.status === 401) {
-    alert('Please log in first');
+    announceDbStatus('Please log in before performing database actions.', 'error');
     window.location = '/login';
     return;
   }
-  const data = await res.json().catch(() => null);
+  if (res.status === 400) {
+    const message = (data && data.error) || 'The supplied date could not be processed.';
+    announceDbStatus(message, 'error');
+    return;
+  }
   if (res.ok && data && data.success) {
-    alert('Old tenders removed');
+    const removed = data.removed ?? 0;
+    const variant = removed > 0 ? 'success' : 'info';
+    const message =
+      removed > 0
+        ? `${removed} tender${removed === 1 ? '' : 's'} older than ${date} removed.`
+        : `No tenders older than ${date} were found.`;
+    announceDbStatus(message, variant);
     loadTenderStats();
   } else {
-    alert('Failed to delete records');
+    announceDbStatus('Failed to delete records.', 'error');
   }
 });
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -76,6 +76,93 @@ button:hover {
   background-color: #0b5ed7;
 }
 
+/* Admin database tools layout */
+.panel-text {
+  margin-top: 0.75rem;
+}
+
+.db-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.db-action {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  padding: 0.75rem;
+  min-width: 240px;
+  max-width: 320px;
+  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
+}
+
+.db-action label {
+  font-weight: 600;
+}
+
+.db-action input[type="date"] {
+  padding: 0.4rem;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+}
+
+.form-hint {
+  font-size: 0.85em;
+  color: #6c757d;
+}
+
+.status-banner {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 6px;
+  background: #e2e3e5;
+  color: #41464b;
+  font-weight: 500;
+  border: 1px solid #d3d5d7;
+}
+
+.status-banner.success {
+  background: #d1e7dd;
+  color: #0f5132;
+  border-color: #badbcc;
+}
+
+.status-banner.error {
+  background: #f8d7da;
+  color: #842029;
+  border-color: #f5c2c7;
+}
+
+.status-banner.info {
+  background: #cff4fc;
+  color: #055160;
+  border-color: #b6effb;
+}
+
+.status-banner[hidden] {
+  display: none;
+}
+
+#dbTools button.danger,
+button.danger {
+  background-color: #dc3545;
+}
+
+#dbTools button.danger:hover,
+button.danger:hover {
+  background-color: #bb2d3b;
+}
+
+.summary-row {
+  background: #f1f3f5;
+  font-weight: 600;
+}
+
 /* Highlighted callout containing usage help */
 #instructions {
   background: #f5f5f5;

--- a/server/db.js
+++ b/server/db.js
@@ -191,6 +191,64 @@ db.serialize(() => {
   )`);
 });
 
+/**
+ * Convert a tender date string into a normalised Date instance.
+ *
+ * Historical data is often stored using a mix of ISO dates (2024-06-01),
+ * slashed values (01/06/2024) and natural language strings ("7 June 2024").
+ * For comparison queries we convert everything to a midnight UTC timestamp so
+ * lexical quirks do not affect ordering.
+ *
+ * @param {string} value - Raw date string stored in the database.
+ * @returns {Date|null} Date instance when parsing succeeds, otherwise null.
+ */
+function normaliseTenderDate(value) {
+  if (value == null) return null;
+  const str = String(value).trim();
+  if (!str) return null;
+
+  const buildDate = (year, month, day) => {
+    const y = Number.parseInt(year, 10);
+    const m = Number.parseInt(month, 10);
+    const d = Number.parseInt(day, 10);
+    if ([y, m, d].some(num => Number.isNaN(num))) {
+      return null;
+    }
+    const fullYear = y < 100 ? 2000 + y : y;
+    if (m < 1 || m > 12 || d < 1 || d > 31) {
+      return null;
+    }
+    const date = new Date(Date.UTC(fullYear, m - 1, d));
+    if (
+      date.getUTCFullYear() !== fullYear ||
+      date.getUTCMonth() !== m - 1 ||
+      date.getUTCDate() !== d
+    ) {
+      return null;
+    }
+    return date;
+  };
+
+  const isoMatch = str.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
+  if (isoMatch) {
+    return buildDate(isoMatch[1], isoMatch[2], isoMatch[3]);
+  }
+
+  const dmyMatch = str.match(/^(\d{1,2})[./-](\d{1,2})[./-](\d{2,4})$/);
+  if (dmyMatch) {
+    return buildDate(dmyMatch[3], dmyMatch[2], dmyMatch[1]);
+  }
+
+  // Remove ordinal suffixes such as "7th" before handing to Date.parse.
+  const cleaned = str.replace(/(\d+)(st|nd|rd|th)/gi, '$1');
+  const parsed = new Date(cleaned);
+  if (!Number.isNaN(parsed.getTime())) {
+    return buildDate(parsed.getFullYear(), parsed.getMonth() + 1, parsed.getDate());
+  }
+
+  return null;
+}
+
 module.exports = {
   /**
    * Insert a tender into the database if it does not already exist.
@@ -643,9 +701,9 @@ module.exports = {
    */
   deleteAllTenders: () => {
     return new Promise((resolve, reject) => {
-      db.run('DELETE FROM tenders', err => {
+      db.run('DELETE FROM tenders', function (err) {
         if (err) return reject(err);
-        resolve();
+        resolve(this.changes || 0);
       });
     });
   },
@@ -658,9 +716,35 @@ module.exports = {
    */
   deleteTendersBefore: date => {
     return new Promise((resolve, reject) => {
-      db.run('DELETE FROM tenders WHERE date < ?', [date], err => {
+      const cutoff = normaliseTenderDate(date);
+      if (!cutoff) {
+        const error = new Error('Invalid cutoff date');
+        error.code = 'INVALID_DATE';
+        return reject(error);
+      }
+
+      db.all('SELECT id, date FROM tenders', (err, rows) => {
         if (err) return reject(err);
-        resolve();
+
+        const cutoffTime = cutoff.getTime();
+        const idsToDelete = rows
+          .map(row => ({ id: row.id, parsed: normaliseTenderDate(row.date) }))
+          .filter(row => row.parsed && row.parsed.getTime() < cutoffTime)
+          .map(row => row.id);
+
+        if (!idsToDelete.length) {
+          return resolve(0);
+        }
+
+        const placeholders = idsToDelete.map(() => '?').join(',');
+        db.run(
+          `DELETE FROM tenders WHERE id IN (${placeholders})`,
+          idsToDelete,
+          function (deleteErr) {
+            if (deleteErr) return reject(deleteErr);
+            resolve(this.changes || 0);
+          }
+        );
       });
     });
   },
@@ -690,9 +774,9 @@ module.exports = {
    */
   deleteTendersBySource: source => {
     return new Promise((resolve, reject) => {
-      db.run('DELETE FROM tenders WHERE source = ?', [source], err => {
+      db.run('DELETE FROM tenders WHERE source = ?', [source], function (err) {
         if (err) return reject(err);
-        resolve();
+        resolve(this.changes || 0);
       });
     });
   },

--- a/server/index.js
+++ b/server/index.js
@@ -926,8 +926,9 @@ app.post('/admin/reset-db', requireAuth, async (req, res) => {
 // authorised users can perform destructive actions.
 app.post('/admin/delete-all', requireAuth, async (req, res) => {
   try {
-    await db.deleteAllTenders();
-    res.json({ success: true });
+    const removed = await db.deleteAllTenders();
+    logger.info('Deleted %d tenders via delete-all tool', removed);
+    res.json({ success: true, removed });
   } catch (err) {
     logger.error('Failed to delete all tenders:', err);
     res.status(500).json({ error: 'Failed to delete data' });
@@ -939,9 +940,13 @@ app.post('/admin/delete-before', requireAuth, async (req, res) => {
   const date = req.body && req.body.date;
   if (!date) return res.status(400).json({ error: 'Missing date' });
   try {
-    await db.deleteTendersBefore(date);
-    res.json({ success: true });
+    const removed = await db.deleteTendersBefore(date);
+    logger.info('Deleted %d tenders older than %s', removed, date);
+    res.json({ success: true, removed });
   } catch (err) {
+    if (err.code === 'INVALID_DATE') {
+      return res.status(400).json({ error: 'Invalid date supplied' });
+    }
     logger.error('Failed to delete old tenders:', err);
     res.status(500).json({ error: 'Failed to delete data' });
   }
@@ -966,9 +971,9 @@ app.post('/admin/delete-source', requireAuth, async (req, res) => {
   const source = req.body && req.body.source;
   if (!source) return res.status(400).json({ error: 'Missing source' });
   try {
-    await db.deleteTendersBySource(source);
-    logger.info(`Deleted tenders for source ${source}`);
-    res.json({ success: true });
+    const removed = await db.deleteTendersBySource(source);
+    logger.info(`Deleted ${removed} tenders for source ${source}`);
+    res.json({ success: true, removed });
   } catch (err) {
     logger.error('Failed to delete tenders for source:', err);
     res.status(500).json({ error: 'Failed to delete data' });

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -336,4 +336,69 @@ describe('Database helpers', () => {
     expect(titles).to.include('new');
     expect(titles).to.not.include('old');
   });
+
+  it('deleteTendersBefore understands varied date formats', async () => {
+    await db.deleteAllTenders();
+    await db.insertTender(
+      'iso-new',
+      'mix1',
+      '2024-07-10',
+      'd',
+      's',
+      '2024-07-11T00:00:00Z',
+      't',
+      'ocds-m1',
+      '77770001',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      ''
+    );
+    await db.insertTender(
+      'worded-old',
+      'mix2',
+      '7 June 2024',
+      'd',
+      's',
+      '2024-06-08T00:00:00Z',
+      't',
+      'ocds-m2',
+      '77770002',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      ''
+    );
+    await db.insertTender(
+      'slash-old',
+      'mix3',
+      '07/06/2024',
+      'd',
+      's',
+      '2024-06-08T00:00:00Z',
+      't',
+      'ocds-m3',
+      '77770003',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      ''
+    );
+    const removed = await db.deleteTendersBefore('2024-07-01');
+    expect(removed).to.equal(2);
+    const remaining = await db.getTenders();
+    const titles = remaining.map(r => r.title);
+    expect(titles).to.include('iso-new');
+    expect(titles).to.not.include('worded-old');
+    expect(titles).to.not.include('slash-old');
+  });
 });


### PR DESCRIPTION
## Summary
- normalise tender dates before deletions so the admin tools work across legacy formats and return row counts
- update database maintenance endpoints to surface deletion totals and additional logging
- refresh the Database Tools panel with inline status messaging, styled controls, and handling for zero-result operations
- cover the new date parsing behaviour with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d12127b3f4832886853a7dda0c1e65