### PR TITLE
Ensure delete-all clears all scraped data

### DIFF
--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -506,13 +506,33 @@ document.getElementById('deleteAllForm').addEventListener('submit', async e => {
     return;
   }
   if (res.ok && data && data.success) {
-    const removed = data.removed ?? 0;
-    const variant = removed > 0 ? 'success' : 'info';
-    const message =
-      removed > 0
-        ? `${removed} tender${removed === 1 ? '' : 's'} deleted from the database.`
-        : 'No tenders matched the deletion request.';
-    announceDbStatus(message, variant);
+    const summary = data.summary || { tenders: data.removed ?? 0 };
+    const sections = [];
+    const pluralise = (count, singular, plural) =>
+      `${count} ${count === 1 ? singular : plural || `${singular}s`}`;
+
+    if (summary.tenders) {
+      sections.push(pluralise(summary.tenders, 'tender record'));
+    }
+    if (summary.awards) {
+      sections.push(pluralise(summary.awards, 'award record'));
+    }
+    if (summary.awardDetails) {
+      sections.push(pluralise(summary.awardDetails, 'award detail entry'));
+    }
+    if (summary.organisations) {
+      sections.push(pluralise(summary.organisations, 'organisation entry'));
+    }
+    if (summary.sourceStats) {
+      sections.push(pluralise(summary.sourceStats, 'source statistic row'));
+    }
+
+    const hadRemovals = sections.length > 0;
+    const message = hadRemovals
+      ? `Removed ${sections.join('; ')}. Reload the Opportunities page to confirm the empty state.`
+      : 'No stored records were removed. The database was already empty.';
+
+    announceDbStatus(message, hadRemovals ? 'success' : 'info');
     loadTenderStats();
   } else {
     announceDbStatus('Failed to delete records.', 'error');

--- a/server/db.js
+++ b/server/db.js
@@ -694,16 +694,69 @@ module.exports = {
   },
 
   /**
-   * Delete all tenders from the database. Used by admin tools to clear
-   * stored data without dropping and recreating the entire schema.
+   * Delete all scraper output from the database so the UI can return to a
+   * pristine state without recreating the schema. All operations run inside a
+   * transaction so either every table is cleared or none are modified.
    *
-   * @returns {Promise<void>} resolves when all rows are removed
+   * @returns {Promise<{
+   *   tenders:number,
+   *   awards:number,
+   *   awardDetails:number,
+   *   organisations:number,
+   *   sourceStats:number
+   * }>} resolves with a per-table deletion summary so callers can surface
+   * detailed feedback to administrators.
    */
   deleteAllTenders: () => {
+    // Helper executing a statement and resolving with the number of affected
+    // rows. Using a promise wrapper keeps the control-flow readable while
+    // guaranteeing each DELETE happens sequentially.
+    const run = (sql, params = []) =>
+      new Promise((resolve, reject) => {
+        db.run(sql, params, function (err) {
+          if (err) return reject(err);
+          resolve(this.changes || 0);
+        });
+      });
+
     return new Promise((resolve, reject) => {
-      db.run('DELETE FROM tenders', function (err) {
-        if (err) return reject(err);
-        resolve(this.changes || 0);
+      db.serialize(() => {
+        (async () => {
+          const summary = {
+            tenders: 0,
+            awards: 0,
+            awardDetails: 0,
+            organisations: 0,
+            sourceStats: 0
+          };
+
+          try {
+            // BEGIN IMMEDIATE blocks writers which avoids interleaving deletes
+            // with new scraper inserts while the clean-up is in progress.
+            await run('BEGIN IMMEDIATE TRANSACTION');
+
+            // Remove dependent tables first so no orphaned award details or
+            // organisation lookups linger after the purge completes.
+            summary.awardDetails = await run('DELETE FROM award_details');
+            summary.awards = await run('DELETE FROM awards');
+            summary.tenders = await run('DELETE FROM tenders');
+            summary.organisations = await run('DELETE FROM organisations');
+            summary.sourceStats = await run('DELETE FROM source_stats');
+
+            await run('COMMIT');
+            resolve(summary);
+          } catch (err) {
+            try {
+              await run('ROLLBACK');
+            } catch (rollbackErr) {
+              logger.error(
+                'Rollback failed while clearing stored data:',
+                rollbackErr
+              );
+            }
+            reject(err);
+          }
+        })();
       });
     });
   },

--- a/server/index.js
+++ b/server/index.js
@@ -926,9 +926,16 @@ app.post('/admin/reset-db', requireAuth, async (req, res) => {
 // authorised users can perform destructive actions.
 app.post('/admin/delete-all', requireAuth, async (req, res) => {
   try {
-    const removed = await db.deleteAllTenders();
-    logger.info('Deleted %d tenders via delete-all tool', removed);
-    res.json({ success: true, removed });
+    const summary = await db.deleteAllTenders();
+    logger.info(
+      'Cleared %d tenders, %d awards and %d organisations via delete-all tool',
+      summary.tenders,
+      summary.awards,
+      summary.organisations
+    );
+    // Preserve the legacy "removed" field for existing front-end code while
+    // also returning the richer summary so the UI can surface a full breakdown.
+    res.json({ success: true, removed: summary.tenders, summary });
   } catch (err) {
     logger.error('Failed to delete all tenders:', err);
     res.status(500).json({ error: 'Failed to delete data' });

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -322,9 +322,71 @@ describe('Database helpers', () => {
   });
 
   it('deleteAllTenders removes everything', async () => {
-    await db.deleteAllTenders();
-    const count = await db.getTenderCount();
-    expect(count).to.equal(0);
+    // Seed fresh data across every table that should be cleared.
+    await db.insertTender(
+      'cleanup tender',
+      'cleanup-link',
+      '2024-09-01',
+      'desc',
+      'cleanup-source',
+      '2024-09-02T00:00:00Z',
+      'tag',
+      'ocds-clean',
+      '99990000',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      ''
+    );
+    const awardInsert = await db.insertAward(
+      'cleanup award',
+      'cleanup-award-link',
+      '2024-09-01',
+      'desc',
+      'cleanup-award-source',
+      '2024-09-02T00:00:00Z',
+      'tag'
+    );
+    if (awardInsert.changes) {
+      await db.insertAwardDetails(awardInsert.id, { buyer: 'Cleanup Buyer' });
+    }
+    await db.insertOrganisation('Cleanup Customer', 'customer');
+    await db.insertOrganisation('Cleanup Supplier', 'supplier');
+    await db.updateSourceStats('cleanup-source', '2024-09-02T00:00:00Z', 2);
+
+    const tenderCountBefore = await db.getTenderCount();
+    const awardsBeforeRows = await db.getAwards();
+    const awardsBefore = awardsBeforeRows.length;
+    const statsBefore = (await db.getSourceStats()).length;
+    const customersBefore = (await db.getOrganisationsByType('customer')).length;
+    const suppliersBefore = (await db.getOrganisationsByType('supplier')).length;
+
+    let awardDetailsBefore = 0;
+    for (const awardRow of awardsBeforeRows) {
+      const detail = await db.getAwardDetails(awardRow.id);
+      if (detail) awardDetailsBefore += 1;
+    }
+
+    const summary = await db.deleteAllTenders();
+
+    expect(summary.tenders).to.equal(tenderCountBefore);
+    expect(summary.awards).to.equal(awardsBefore);
+    expect(summary.awardDetails).to.equal(awardDetailsBefore);
+    expect(summary.organisations).to.equal(customersBefore + suppliersBefore);
+    expect(summary.sourceStats).to.equal(statsBefore);
+
+    expect(await db.getTenderCount()).to.equal(0);
+    expect((await db.getAwards()).length).to.equal(0);
+    expect((await db.getSourceStats()).length).to.equal(0);
+    expect((await db.getOrganisationsByType('customer')).length).to.equal(0);
+    expect((await db.getOrganisationsByType('supplier')).length).to.equal(0);
+    if (awardInsert.changes) {
+      const detailAfter = await db.getAwardDetails(awardInsert.id);
+      expect(detailAfter).to.equal(null);
+    }
   });
 
   it('deleteTendersBefore removes only old rows', async () => {


### PR DESCRIPTION
## Summary
- wrap the delete-all helper in a transaction that purges tenders, awards, organisations and source statistics while returning a detailed summary
- update the admin endpoint and UI to display the full deletion breakdown and prompt operators to refresh the Opportunities view
- expand the database test suite to cover the multi-table purge behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d12f643a9083288b0fe3912919f21e