### PR TITLE
Reset last-scraped metadata during delete-all cleanup

### DIFF
--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -526,10 +526,13 @@ document.getElementById('deleteAllForm').addEventListener('submit', async e => {
     if (summary.sourceStats) {
       sections.push(pluralise(summary.sourceStats, 'source statistic row'));
     }
+    if (summary.metadata) {
+      sections.push(pluralise(summary.metadata, 'metadata entry'));
+    }
 
     const hadRemovals = sections.length > 0;
     const message = hadRemovals
-      ? `Removed ${sections.join('; ')}. Reload the Opportunities page to confirm the empty state.`
+      ? `Removed ${sections.join('; ')}. Reload the Opportunities and Stats pages to confirm the empty state.`
       : 'No stored records were removed. The database was already empty.';
 
     announceDbStatus(message, hadRemovals ? 'success' : 'info');

--- a/server/db.js
+++ b/server/db.js
@@ -703,7 +703,8 @@ module.exports = {
    *   awards:number,
    *   awardDetails:number,
    *   organisations:number,
-   *   sourceStats:number
+   *   sourceStats:number,
+   *   metadata:number
    * }>} resolves with a per-table deletion summary so callers can surface
    * detailed feedback to administrators.
    */
@@ -727,7 +728,8 @@ module.exports = {
             awards: 0,
             awardDetails: 0,
             organisations: 0,
-            sourceStats: 0
+            sourceStats: 0,
+            metadata: 0
           };
 
           try {
@@ -742,6 +744,12 @@ module.exports = {
             summary.tenders = await run('DELETE FROM tenders');
             summary.organisations = await run('DELETE FROM organisations');
             summary.sourceStats = await run('DELETE FROM source_stats');
+            // Reset metadata that only reflects stored tender data. Other keys
+            // such as the cron schedule are preserved so admin configuration
+            // survives a clean-up operation.
+            summary.metadata = await run(
+              "DELETE FROM metadata WHERE key = 'last_scraped'"
+            );
 
             await run('COMMIT');
             resolve(summary);

--- a/server/index.js
+++ b/server/index.js
@@ -928,10 +928,13 @@ app.post('/admin/delete-all', requireAuth, async (req, res) => {
   try {
     const summary = await db.deleteAllTenders();
     logger.info(
-      'Cleared %d tenders, %d awards and %d organisations via delete-all tool',
+      'Cleared %d tenders, %d awards, %d award detail rows, %d organisations, %d source stats entries and %d metadata records via delete-all tool',
       summary.tenders,
       summary.awards,
-      summary.organisations
+      summary.awardDetails,
+      summary.organisations,
+      summary.sourceStats,
+      summary.metadata
     );
     // Preserve the legacy "removed" field for existing front-end code while
     // also returning the richer summary so the UI can surface a full breakdown.

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -356,6 +356,7 @@ describe('Database helpers', () => {
     await db.insertOrganisation('Cleanup Customer', 'customer');
     await db.insertOrganisation('Cleanup Supplier', 'supplier');
     await db.updateSourceStats('cleanup-source', '2024-09-02T00:00:00Z', 2);
+    await db.setLastScraped('2024-09-02T00:00:00Z');
 
     const tenderCountBefore = await db.getTenderCount();
     const awardsBeforeRows = await db.getAwards();
@@ -377,12 +378,14 @@ describe('Database helpers', () => {
     expect(summary.awardDetails).to.equal(awardDetailsBefore);
     expect(summary.organisations).to.equal(customersBefore + suppliersBefore);
     expect(summary.sourceStats).to.equal(statsBefore);
+    expect(summary.metadata).to.equal(1);
 
     expect(await db.getTenderCount()).to.equal(0);
     expect((await db.getAwards()).length).to.equal(0);
     expect((await db.getSourceStats()).length).to.equal(0);
     expect((await db.getOrganisationsByType('customer')).length).to.equal(0);
     expect((await db.getOrganisationsByType('supplier')).length).to.equal(0);
+    expect(await db.getLastScraped()).to.equal(null);
     if (awardInsert.changes) {
       const detailAfter = await db.getAwardDetails(awardInsert.id);
       expect(detailAfter).to.equal(null);


### PR DESCRIPTION
## Summary
- clear the last_scraped metadata entry when running the delete-all purge so the Stats page resets fully
- surface the metadata deletion in server logging and the admin UI status message to aid administrators
- extend the database test coverage to confirm metadata is wiped alongside tenders and awards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d146a7f3cc83288fc1274139001909