### PR TITLE
Add admin console for database and user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ pkill -f "node server/index.js"
     `/login` and visiting `/scraper`. Once logged in your session persists for 30 days
     so you remain authenticated after closing the browser. Only
     authenticated users can access these management functions.
+  - **Open the Admin tab** for a consolidated console that lists live database
+    statistics, offers a confirmation-protected wipe button and lets
+    administrators create, reset or delete user accounts without touching the
+    underlying SQLite files.
   - **Automatic scraping** runs in the background according to the `CRON_SCHEDULE`
   environment variable (default `0 6 * * *`). Results are stored in the
   database without any manual interaction.

--- a/frontend/admin-tools.js
+++ b/frontend/admin-tools.js
@@ -1,0 +1,462 @@
+/**
+ * @file admin-tools.js
+ * @description Client-side controller for the administration console. Handles
+ *   destructive database actions, dynamic statistics refreshes and user
+ *   management operations with friendly status updates and confirmation
+ *   dialogues.
+ */
+'use strict';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const dataEl = document.getElementById('adminData');
+  let initial = {};
+  try {
+    initial = dataEl ? JSON.parse(dataEl.textContent) : {};
+  } catch (err) {
+    console.error('Failed to parse initial admin data payload', err);
+  }
+
+  const state = {
+    counts: Object.assign(
+      {
+        tenders: 0,
+        awards: 0,
+        customers: 0,
+        suppliers: 0,
+        totalSources: 0,
+        totalAwardSources: 0,
+        users: 0
+      },
+      initial.counts || {}
+    ),
+    lastScraped: initial.lastScraped || null,
+    tenderBreakdown: initial.tenderBreakdown || [],
+    users: (initial.users || []).map(user => ({
+      id: user.id,
+      username: user.username,
+      isAdmin: Boolean(user.isAdmin)
+    })),
+    adminUsersConfigured: Boolean(initial.adminUsersConfigured),
+    adminUsernames: initial.adminUsernames || [],
+    currentUser: initial.currentUser || null
+  };
+  state.counts.users = state.users.length;
+
+  const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+  const csrfToken = csrfMeta ? csrfMeta.content : '';
+  const dbStatus = document.getElementById('dbStatus');
+  const userStatus = document.getElementById('userStatus');
+  const tenderBody = document.getElementById('tenderBreakdownBody');
+  const userBody = document.getElementById('userTableBody');
+  const lastScrapedEl = document.getElementById('lastScraped');
+  const wipeButton = document.getElementById('wipeDatabase');
+  const refreshButton = document.getElementById('refreshBreakdown');
+  const createForm = document.getElementById('createUserForm');
+  const confirmDialog = document.getElementById('confirmWipeDialog');
+  const confirmForm = document.getElementById('confirmWipeForm');
+  const passwordDialog = document.getElementById('passwordDialog');
+  const passwordForm = document.getElementById('passwordForm');
+  const passwordUserId = document.getElementById('passwordUserId');
+  const passwordInput = document.getElementById('passwordInput');
+  const passwordConfirmInput = document.getElementById('passwordConfirmInput');
+
+  /**
+   * Display a status message within the supplied banner element.
+   *
+   * @param {HTMLElement} el - Target banner element
+   * @param {string} message - Human friendly message
+   * @param {'info'|'success'|'error'} type - Visual style to apply
+   */
+  function announce(el, message, type = 'info') {
+    if (!el) return;
+    el.textContent = message;
+    el.classList.remove('info', 'success', 'error');
+    el.classList.add(type);
+    el.hidden = false;
+  }
+
+  /** Hide the supplied status banner. */
+  function hideStatus(el) {
+    if (!el) return;
+    el.hidden = true;
+    el.textContent = '';
+  }
+
+  /** Update the numeric stat cards from the current state. */
+  function updateStatCards() {
+    const entries = [
+      ['statTenders', state.counts.tenders],
+      ['statAwards', state.counts.awards],
+      ['statCustomers', state.counts.customers],
+      ['statSuppliers', state.counts.suppliers],
+      ['statSources', state.counts.totalSources],
+      ['statAwardSources', state.counts.totalAwardSources],
+      ['statUsers', state.counts.users]
+    ];
+    entries.forEach(([id, value]) => {
+      const el = document.getElementById(id);
+      if (el) el.textContent = typeof value === 'number' ? value : '0';
+    });
+    if (lastScrapedEl) {
+      const val = state.lastScraped || lastScrapedEl.dataset.empty;
+      lastScrapedEl.textContent = val;
+    }
+  }
+
+  /** Render the tender breakdown table using state.tenderBreakdown. */
+  function renderTenderBreakdown() {
+    if (!tenderBody) return;
+    tenderBody.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    if (!state.tenderBreakdown.length) {
+      const row = document.createElement('tr');
+      row.className = 'table-empty';
+      const cell = document.createElement('td');
+      cell.colSpan = 2;
+      cell.textContent = 'No tenders stored yet.';
+      row.appendChild(cell);
+      fragment.appendChild(row);
+    } else {
+      state.tenderBreakdown.forEach(entry => {
+        const row = document.createElement('tr');
+        const source = document.createElement('td');
+        source.textContent = entry.source;
+        const count = document.createElement('td');
+        count.textContent = entry.count;
+        row.append(source, count);
+        fragment.appendChild(row);
+      });
+    }
+    tenderBody.appendChild(fragment);
+  }
+
+  /** Render the user table from the current state. */
+  function renderUsers() {
+    if (!userBody) return;
+    userBody.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    if (!state.users.length) {
+      const row = document.createElement('tr');
+      row.className = 'table-empty';
+      const cell = document.createElement('td');
+      cell.colSpan = 3;
+      cell.textContent = 'No users registered.';
+      row.appendChild(cell);
+      fragment.appendChild(row);
+    } else {
+      const current = state.currentUser ? state.currentUser.toLowerCase() : null;
+      state.users
+        .slice()
+        .sort((a, b) => a.username.localeCompare(b.username))
+        .forEach(account => {
+          const row = document.createElement('tr');
+          row.dataset.userId = account.id;
+
+          const nameCell = document.createElement('td');
+          const nameSpan = document.createElement('span');
+          nameSpan.className = 'username-cell';
+          nameSpan.textContent = account.username;
+          nameCell.appendChild(nameSpan);
+
+          const roleCell = document.createElement('td');
+          const badge = document.createElement('span');
+          badge.className = `badge ${account.isAdmin ? 'badge-admin' : 'badge-user'}`;
+          badge.textContent = account.isAdmin ? 'Administrator' : 'Standard';
+          roleCell.appendChild(badge);
+
+          const actionCell = document.createElement('td');
+          const resetBtn = document.createElement('button');
+          resetBtn.type = 'button';
+          resetBtn.className = 'secondary reset-password';
+          resetBtn.textContent = 'Reset password';
+          const deleteBtn = document.createElement('button');
+          deleteBtn.type = 'button';
+          deleteBtn.className = 'danger delete-user';
+          deleteBtn.textContent = 'Delete';
+
+          const isSelf = current && account.username.toLowerCase() === current;
+          if (isSelf) {
+            deleteBtn.disabled = true;
+            deleteBtn.title = 'You cannot delete the account currently in use';
+          }
+
+          actionCell.append(resetBtn, deleteBtn);
+          row.append(nameCell, roleCell, actionCell);
+          fragment.appendChild(row);
+        });
+    }
+    userBody.appendChild(fragment);
+  }
+
+  updateStatCards();
+  renderTenderBreakdown();
+  renderUsers();
+
+  function redirectToLogin() {
+    window.location.href = '/login';
+  }
+
+  async function performWipe() {
+    hideStatus(dbStatus);
+    announce(dbStatus, 'Clearing stored data…', 'info');
+    console.info('Administrator triggered full database wipe');
+    try {
+      const res = await fetch('/admin/delete-all', {
+        method: 'POST',
+        headers: { Accept: 'application/json', 'CSRF-Token': csrfToken }
+      });
+      const body = await res.json().catch(() => null);
+      if (res.status === 401) {
+        redirectToLogin();
+        return;
+      }
+      if (res.status === 403) {
+        announce(dbStatus, 'Administrator access required to wipe the database.', 'error');
+        return;
+      }
+      if (!res.ok || !body || !body.success) {
+        announce(dbStatus, 'Failed to wipe stored data. Check server logs for details.', 'error');
+        return;
+      }
+      const summary = body.summary || {};
+      state.counts.tenders = 0;
+      state.counts.awards = 0;
+      state.counts.customers = 0;
+      state.counts.suppliers = 0;
+      state.tenderBreakdown = [];
+      state.lastScraped = null;
+      updateStatCards();
+      renderTenderBreakdown();
+      const removedTenders = summary.tenders || 0;
+      announce(
+        dbStatus,
+        removedTenders
+          ? `Database wiped successfully. Removed ${removedTenders} tender records along with related award and organisation data.`
+          : 'Database wipe completed. No tender records were present.',
+        'success'
+      );
+    } catch (err) {
+      console.error('Wipe request failed', err);
+      announce(dbStatus, 'Unexpected error wiping data. See browser console for details.', 'error');
+    }
+  }
+
+  async function refreshStats() {
+    hideStatus(dbStatus);
+    announce(dbStatus, 'Refreshing statistics…', 'info');
+    console.info('Refreshing admin statistics view');
+    try {
+      const res = await fetch('/admin/db-info', { headers: { Accept: 'application/json' } });
+      if (res.status === 401) {
+        redirectToLogin();
+        return;
+      }
+      if (res.status === 403) {
+        announce(dbStatus, 'Administrator access required to read database statistics.', 'error');
+        return;
+      }
+      const data = await res.json();
+      state.tenderBreakdown = data.counts || [];
+      state.counts.tenders = data.total || 0;
+      state.counts.awards = data.awardCount || 0;
+      state.counts.customers = data.customerCount || 0;
+      state.counts.suppliers = data.supplierCount || 0;
+      state.counts.totalSources = data.sourceCount || 0;
+      state.counts.totalAwardSources = data.awardSourceCount || 0;
+      state.lastScraped = data.lastScraped || null;
+      updateStatCards();
+      renderTenderBreakdown();
+      announce(dbStatus, 'Statistics updated.', 'success');
+    } catch (err) {
+      console.error('Failed to refresh statistics', err);
+      announce(dbStatus, 'Could not refresh statistics. Check connectivity.', 'error');
+    }
+  }
+
+  if (wipeButton && confirmDialog && confirmForm) {
+    wipeButton.addEventListener('click', () => {
+      confirmDialog.showModal();
+    });
+    const cancelBtn = confirmDialog.querySelector('[data-action="cancel"]');
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', () => {
+        confirmDialog.close();
+      });
+    }
+    confirmForm.addEventListener('submit', evt => {
+      evt.preventDefault();
+      confirmDialog.close();
+      performWipe();
+    });
+  }
+
+  if (refreshButton) {
+    refreshButton.addEventListener('click', refreshStats);
+  }
+
+  if (createForm) {
+    createForm.addEventListener('submit', async evt => {
+      evt.preventDefault();
+      hideStatus(userStatus);
+      const formData = new FormData(createForm);
+      const username = formData.get('username').trim();
+      const password = formData.get('password');
+      if (!username || !password) {
+        announce(userStatus, 'Provide both a username and password.', 'info');
+        return;
+      }
+      announce(userStatus, `Creating account for ${username}…`, 'info');
+      console.info('Creating user via admin console', username);
+      try {
+        const res = await fetch('/admin/users', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'CSRF-Token': csrfToken
+          },
+          body: JSON.stringify({ username, password })
+        });
+        const data = await res.json().catch(() => null);
+        if (res.status === 401) {
+          redirectToLogin();
+          return;
+        }
+        if (res.status === 403) {
+          announce(userStatus, 'Administrator access required to create users.', 'error');
+          return;
+        }
+        if (res.status === 409) {
+          announce(userStatus, 'That username is already taken. Choose another.', 'error');
+          return;
+        }
+        if (!res.ok || !data || !data.user) {
+          announce(userStatus, 'Failed to create user. Check server logs.', 'error');
+          return;
+        }
+        state.users.push({
+          id: data.user.id,
+          username: data.user.username,
+          isAdmin: Boolean(data.user.isAdmin)
+        });
+        state.counts.users = state.users.length;
+        updateStatCards();
+        renderUsers();
+        createForm.reset();
+        announce(userStatus, `User ${username} created. Share credentials securely.`, 'success');
+      } catch (err) {
+        console.error('Failed to create user', err);
+        announce(userStatus, 'Unexpected error creating user.', 'error');
+      }
+    });
+  }
+
+  if (userBody) {
+    userBody.addEventListener('click', evt => {
+      const row = evt.target.closest('tr[data-user-id]');
+      if (!row) return;
+      const userId = Number.parseInt(row.dataset.userId, 10);
+      const username = row.querySelector('.username-cell').textContent;
+      if (evt.target.classList.contains('reset-password')) {
+        passwordUserId.value = String(userId);
+        passwordInput.value = '';
+        passwordConfirmInput.value = '';
+        passwordDialog.showModal();
+        passwordDialog.dataset.username = username;
+      } else if (evt.target.classList.contains('delete-user')) {
+        if (!confirm(`Delete user ${username}? This cannot be undone.`)) return;
+        deleteUser(userId, username);
+      }
+    });
+  }
+
+  if (passwordDialog) {
+    const cancelBtn = passwordDialog.querySelector('[data-action="cancel"]');
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', () => passwordDialog.close());
+    }
+  }
+
+  if (passwordForm) {
+    passwordForm.addEventListener('submit', async evt => {
+      evt.preventDefault();
+      const id = Number.parseInt(passwordUserId.value, 10);
+      const password = passwordInput.value;
+      const confirm = passwordConfirmInput.value;
+      if (!password || password !== confirm) {
+        announce(userStatus, 'Passwords must match and be at least 8 characters.', 'error');
+        return;
+      }
+      try {
+        console.info('Resetting password via admin console for', passwordDialog.dataset.username);
+        const res = await fetch(`/admin/users/${id}/password`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'CSRF-Token': csrfToken
+          },
+          body: JSON.stringify({ password })
+        });
+        if (res.status === 401) {
+          redirectToLogin();
+          return;
+        }
+        if (res.status === 403) {
+          announce(userStatus, 'Administrator access required to reset passwords.', 'error');
+          return;
+        }
+        if (!res.ok) {
+          announce(userStatus, 'Failed to reset password. Try again.', 'error');
+          return;
+        }
+        passwordDialog.close();
+        announce(userStatus, `Password reset for ${passwordDialog.dataset.username}.`, 'success');
+      } catch (err) {
+        console.error('Failed to reset password', err);
+        announce(userStatus, 'Unexpected error resetting password.', 'error');
+      }
+    });
+  }
+
+  async function deleteUser(id, username) {
+    hideStatus(userStatus);
+    announce(userStatus, `Deleting user ${username}…`, 'info');
+    console.info('Deleting user via admin console', username);
+    try {
+      const res = await fetch(`/admin/users/${id}`, {
+        method: 'DELETE',
+        headers: { Accept: 'application/json', 'CSRF-Token': csrfToken }
+      });
+      if (res.status === 401) {
+        redirectToLogin();
+        return;
+      }
+      if (res.status === 403) {
+        announce(userStatus, 'Administrator access required to delete users.', 'error');
+        return;
+      }
+      if (res.status === 400) {
+        const data = await res.json().catch(() => ({}));
+        announce(userStatus, data.error || 'Cannot delete that account.', 'error');
+        return;
+      }
+      if (res.status === 404) {
+        announce(userStatus, 'User not found. Refresh the page.', 'error');
+        return;
+      }
+      if (!res.ok) {
+        announce(userStatus, 'Failed to delete user. Check logs.', 'error');
+        return;
+      }
+      state.users = state.users.filter(user => user.id !== id);
+      state.counts.users = state.users.length;
+      updateStatCards();
+      renderUsers();
+      announce(userStatus, `User ${username} deleted.`, 'success');
+    } catch (err) {
+      console.error('Failed to delete user', err);
+      announce(userStatus, 'Unexpected error deleting user.', 'error');
+    }
+  }
+});

--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -1,0 +1,195 @@
+<!--
+  @file admin.ejs
+  @description Primary administration console combining database maintenance
+    utilities with user management tooling. The page is rendered server-side so
+    the latest statistics are available immediately while client-side scripts
+    handle destructive actions with confirmation dialogues.
+  @structure
+    1. Page header and navigation tabs.
+    2. Summary cards showing live system metrics.
+    3. Database tools for wiping or inspecting stored data.
+    4. User administration area for creating, resetting and deleting accounts.
+    5. Lightweight dialog components for confirmations and password updates.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Admin Console</title>
+  <link rel="stylesheet" href="/style.css">
+  <meta name="csrf-token" content="<%= csrfToken %>">
+</head>
+<body>
+  <h1>Administration Console</h1>
+  <%- include('partials/nav', { page: 'admin', user: user, isAdmin: isAdmin }) %>
+  <p class="page-intro">Monitor system health, prune stored tenders and manage
+    team access in one place. Review the metrics below before triggering any
+    destructive operation.</p>
+
+  <% if (!adminUsersConfigured) { %>
+    <div class="status-banner info" role="alert">
+      All authenticated users currently have administrator rights because
+      <code>ADMIN_USERS</code> is not configured. Set that environment variable
+      to restrict access to this console in production.
+    </div>
+  <% } %>
+
+  <section class="stat-grid" aria-label="System metrics">
+    <article class="stat-card" aria-labelledby="stat-tenders">
+      <h2 id="stat-tenders">Tenders</h2>
+      <p id="statTenders" class="stat-value"><%= counts.tenders %></p>
+      <p class="stat-note">records stored</p>
+    </article>
+    <article class="stat-card" aria-labelledby="stat-awards">
+      <h2 id="stat-awards">Awards</h2>
+      <p id="statAwards" class="stat-value"><%= counts.awards %></p>
+      <p class="stat-note">award notices retained</p>
+    </article>
+    <article class="stat-card" aria-labelledby="stat-customers">
+      <h2 id="stat-customers">Customers</h2>
+      <p id="statCustomers" class="stat-value"><%= counts.customers %></p>
+      <p class="stat-note">organisations referenced as buyers</p>
+    </article>
+    <article class="stat-card" aria-labelledby="stat-suppliers">
+      <h2 id="stat-suppliers">Suppliers</h2>
+      <p id="statSuppliers" class="stat-value"><%= counts.suppliers %></p>
+      <p class="stat-note">supplier organisations tracked</p>
+    </article>
+    <article class="stat-card" aria-labelledby="stat-sources">
+      <h2 id="stat-sources">Active sources</h2>
+      <p id="statSources" class="stat-value"><%= counts.totalSources %></p>
+      <p class="stat-note">tender feeds configured</p>
+    </article>
+    <article class="stat-card" aria-labelledby="stat-award-sources">
+      <h2 id="stat-award-sources">Award sources</h2>
+      <p id="statAwardSources" class="stat-value"><%= counts.totalAwardSources %></p>
+      <p class="stat-note">award feeds configured</p>
+    </article>
+    <article class="stat-card" aria-labelledby="stat-users">
+      <h2 id="stat-users">Users</h2>
+      <p id="statUsers" class="stat-value"><%= counts.users %></p>
+      <p class="stat-note">registered accounts</p>
+    </article>
+  </section>
+  <p class="stat-note">Last successful scrape:
+    <span id="lastScraped" data-empty="No scrape recorded yet">
+      <%= lastScraped ? lastScraped : 'No scrape recorded yet' %>
+    </span>
+  </p>
+
+  <section id="db-admin" class="panel" aria-labelledby="db-admin-heading">
+    <div class="panel-header">
+      <h2 id="db-admin-heading">Database administration</h2>
+      <p>Take extreme care when wiping data&mdash;the action is irreversible. Logs
+        are written to <code>logs/app.log</code> for full auditability.</p>
+    </div>
+    <div id="dbStatus" class="status-banner" role="status" aria-live="polite" hidden></div>
+    <div class="action-row">
+      <button id="wipeDatabase" class="danger">Wipe all stored data</button>
+      <button id="refreshBreakdown" class="secondary">Refresh statistics</button>
+    </div>
+    <p class="hint">Refreshing statistics pulls a live breakdown from the
+      server without reloading the page.</p>
+    <table id="tenderBreakdownTable">
+      <thead>
+        <tr><th scope="col">Source</th><th scope="col">Tender count</th></tr>
+      </thead>
+      <tbody id="tenderBreakdownBody">
+        <% if (tenderBreakdown.length === 0) { %>
+          <tr class="table-empty"><td colspan="2">No tenders stored yet.</td></tr>
+        <% } else { %>
+          <% tenderBreakdown.forEach(row => { %>
+            <tr>
+              <td><%= row.source %></td>
+              <td><%= row.count %></td>
+            </tr>
+          <% }) %>
+        <% } %>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="user-administration" class="panel" aria-labelledby="user-admin-heading">
+    <div class="panel-header">
+      <h2 id="user-admin-heading">User administration</h2>
+      <p>Create accounts for colleagues, reset forgotten passwords and revoke
+        access. Every action is logged in the server console for transparency.</p>
+    </div>
+    <div id="userStatus" class="status-banner" role="status" aria-live="polite" hidden></div>
+    <form id="createUserForm" class="form-inline" autocomplete="off">
+      <div class="form-field">
+        <label for="newUsername">Username</label>
+        <input id="newUsername" name="username" type="text" required minlength="3" autocomplete="off">
+      </div>
+      <div class="form-field">
+        <label for="newPassword">Password</label>
+        <input id="newPassword" name="password" type="password" required minlength="8" autocomplete="new-password">
+      </div>
+      <button type="submit">Create user</button>
+    </form>
+    <table id="userTable">
+      <thead>
+        <tr><th scope="col">Username</th><th scope="col">Role</th><th scope="col">Actions</th></tr>
+      </thead>
+      <tbody id="userTableBody">
+        <% if (users.length === 0) { %>
+          <tr class="table-empty"><td colspan="3">No users registered.</td></tr>
+        <% } else { %>
+          <% users.forEach(account => { %>
+            <tr data-user-id="<%= account.id %>">
+              <td><span class="username-cell"><%= account.username %></span></td>
+              <td><span class="badge <%= account.isAdmin ? 'badge-admin' : 'badge-user' %>"><%= account.isAdmin ? 'Administrator' : 'Standard' %></span></td>
+              <td>
+                <button type="button" class="secondary reset-password">Reset password</button>
+                <button type="button" class="danger delete-user">Delete</button>
+              </td>
+            </tr>
+          <% }) %>
+        <% } %>
+      </tbody>
+    </table>
+  </section>
+
+  <dialog id="confirmWipeDialog">
+    <form id="confirmWipeForm" method="dialog">
+      <h3>Confirm database wipe</h3>
+      <p>This will permanently delete all stored tenders, awards, organisations
+        and related metadata. Back up the SQLite database before proceeding.</p>
+      <div class="dialog-actions">
+        <button type="submit" class="danger">Yes, wipe everything</button>
+        <button type="button" data-action="cancel" class="secondary">Cancel</button>
+      </div>
+    </form>
+  </dialog>
+
+  <dialog id="passwordDialog">
+    <form id="passwordForm" method="dialog">
+      <h3>Reset user password</h3>
+      <input type="hidden" id="passwordUserId">
+      <div class="form-field">
+        <label for="passwordInput">New password</label>
+        <input id="passwordInput" type="password" required minlength="8" autocomplete="new-password">
+      </div>
+      <div class="form-field">
+        <label for="passwordConfirmInput">Confirm password</label>
+        <input id="passwordConfirmInput" type="password" required minlength="8" autocomplete="new-password">
+      </div>
+      <div class="dialog-actions">
+        <button type="submit">Update password</button>
+        <button type="button" data-action="cancel" class="secondary">Cancel</button>
+      </div>
+    </form>
+  </dialog>
+
+  <script id="adminData" type="application/json"><%- JSON.stringify({
+    counts,
+    lastScraped,
+    tenderBreakdown,
+    users,
+    cron,
+    adminUsersConfigured,
+    adminUsernames,
+    currentUser
+  }).replace(/</g, '\\u003c') %></script>
+  <script type="module" src="/admin-tools.js"></script>
+</body>
+</html>

--- a/frontend/manage-users.ejs
+++ b/frontend/manage-users.ejs
@@ -1,3 +1,13 @@
+<!--
+  @file manage-users.ejs
+  @description Legacy landing page retained so the profile dropdown can include
+    a "Manage Users" option for all members. Administrators are redirected to
+    the rich Admin console while standard users see guidance on how to request
+    elevated access.
+  @structure
+    - Shared navigation bar for consistency.
+    - Friendly notice with next steps for non-administrators.
+-->
 <!DOCTYPE html>
 <html>
 <head>
@@ -8,7 +18,14 @@
   <h1>Manage Users</h1>
   <!-- Navigation with profile dropdown remains consistent -->
   <%- include('partials/nav', { page: 'manage-users', user: user }) %>
-  <!-- Explain the purpose of the screen to avoid confusion -->
-  <p>Add, remove or update user accounts from this administration area.</p>
+  <div class="panel">
+    <h2>Requesting administrative access</h2>
+    <p>This area is limited to system administrators so every change can be
+      audited and secured. If your role requires user management or database
+      maintenance tools, ask an administrator to add your account to the
+      <code>ADMIN_USERS</code> environment setting.</p>
+    <p>Administrators can open the full toolkit via the <strong>Admin</strong>
+      tab at the top of the screen.</p>
+  </div>
 </body>
 </html>

--- a/frontend/partials/nav.ejs
+++ b/frontend/partials/nav.ejs
@@ -1,3 +1,13 @@
+<!--
+  @file nav.ejs
+  @description Shared navigation tabs for the procurement dashboard. This
+    partial renders all top-level sections plus the authenticated user dropdown
+    so each page has a consistent experience.
+  @structure
+    - Horizontal tab list for primary sections.
+    - Conditional Admin tab for privileged users.
+    - Profile dropdown providing quick links to account tools.
+-->
 <ul class="tabs">
   <li class="<%= page === 'dashboard' ? 'active' : '' %>"><a href="/dashboard">Dashboard</a></li>
   <li class="<%= page === 'opportunities' ? 'active' : '' %>"><a href="/opportunities">Opportunities</a></li>
@@ -5,6 +15,9 @@
   <li class="<%= page === 'scraper' ? 'active' : '' %>"><a href="/scraper">Scraper</a></li>
   <li class="<%= page === 'crm' ? 'active' : '' %>"><a href="/crm">CRM</a></li>
   <li class="<%= page === 'stats' ? 'active' : '' %>"><a href="/stats">Stats</a></li>
+  <% if (user && isAdmin) { %>
+    <li class="<%= page === 'admin' ? 'active' : '' %>"><a href="/admin">Admin</a></li>
+  <% } %>
   <li class="<%= page === 'help' ? 'active' : '' %>"><a href="/help">Help</a></li>
   <% if (user) { %>
     <!-- Profile dropdown shown when user is authenticated -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -148,6 +148,160 @@ button:hover {
   display: none;
 }
 
+/* Administration dashboard layout ------------------------------------------------ */
+.page-intro {
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  color: #495057;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.stat-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+  border: 1px solid #dee2e6;
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
+}
+
+.stat-card h2 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0.3rem 0;
+  color: #1d4ed8;
+}
+
+.stat-note {
+  font-size: 0.9rem;
+  color: #6c757d;
+}
+
+.panel {
+  margin-top: 1.75rem;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 1.25rem;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.05);
+}
+
+.panel-header {
+  margin-bottom: 1rem;
+}
+
+.panel-header h2 {
+  margin: 0 0 0.35rem 0;
+}
+
+.panel .hint {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #6c757d;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+button.secondary {
+  background: #6c757d;
+}
+
+button.secondary:hover {
+  background: #5c636a;
+}
+
+.form-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+}
+
+.form-field label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.form-field input {
+  padding: 0.45rem;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+}
+
+#userTable button {
+  margin-right: 0.4rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.badge-admin {
+  background: #d1e7dd;
+  color: #0f5132;
+}
+
+.badge-user {
+  background: #e2e3e5;
+  color: #41464b;
+}
+
+.username-cell {
+  font-weight: 600;
+}
+
+.table-empty td {
+  text-align: center;
+  color: #6c757d;
+}
+
+dialog {
+  border: none;
+  border-radius: 10px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.3);
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.dialog-actions button {
+  min-width: 120px;
+}
+
 #dbTools button.danger,
 button.danger {
   background-color: #dc3545;

--- a/server/db.js
+++ b/server/db.js
@@ -987,6 +987,24 @@ module.exports = {
   },
 
   /**
+   * Retrieve all user accounts. Only the identifier and username are returned
+   * so no credential data ever leaves the database layer.
+   *
+   * @returns {Promise<Array<{id:number,username:string}>>} sorted list of users
+   */
+  getAllUsers: () => {
+    return new Promise((resolve, reject) => {
+      db.all(
+        'SELECT id, username FROM users ORDER BY username COLLATE NOCASE',
+        (err, rows) => {
+          if (err) return reject(err);
+          resolve(rows);
+        }
+      );
+    });
+  },
+
+  /**
    * Look up a user by username.
    *
    * @param {string} username - Username to search for
@@ -1002,6 +1020,58 @@ module.exports = {
           resolve(row || null);
         }
       );
+    });
+  },
+
+  /**
+   * Look up a user by numeric identifier. Mirrors getUserByUsername but uses
+   * the primary key which is convenient for admin tooling.
+   *
+   * @param {number} id - Identifier of the account
+   * @returns {Promise<object|null>} matching row or null when absent
+   */
+  getUserById: id => {
+    return new Promise((resolve, reject) => {
+      db.get('SELECT id, username FROM users WHERE id = ?', [id], (err, row) => {
+        if (err) return reject(err);
+        resolve(row || null);
+      });
+    });
+  },
+
+  /**
+   * Update a user's stored password hash. The caller is responsible for hashing
+   * the password before invoking this helper.
+   *
+   * @param {number} id - Identifier of the account to update
+   * @param {string} passwordHash - New bcrypt hash to store
+   * @returns {Promise<number>} resolves with number of affected rows
+   */
+  updateUserPassword: (id, passwordHash) => {
+    return new Promise((resolve, reject) => {
+      db.run(
+        'UPDATE users SET password = ? WHERE id = ?',
+        [passwordHash, id],
+        function (err) {
+          if (err) return reject(err);
+          resolve(this.changes || 0);
+        }
+      );
+    });
+  },
+
+  /**
+   * Permanently delete a user account.
+   *
+   * @param {number} id - Identifier of the user to remove
+   * @returns {Promise<number>} number of rows deleted
+   */
+  deleteUser: id => {
+    return new Promise((resolve, reject) => {
+      db.run('DELETE FROM users WHERE id = ?', [id], function (err) {
+        if (err) return reject(err);
+        resolve(this.changes || 0);
+      });
     });
   },
 

--- a/server/index.js
+++ b/server/index.js
@@ -231,10 +231,36 @@ app.use(
 // Attach CSRF protection and expose helper to templates.
 app.use(csrf());
 
-// Make the current user and a CSRF token available to all templates.
+// Build a set of administrator usernames from the ADMIN_USERS environment
+// variable. When empty, all authenticated users are treated as administrators
+// so optional permission checks fall back to simple authentication.
+const adminUsers = new Set(
+  (process.env.ADMIN_USERS || '')
+    .split(',')
+    .map(u => u.trim().toLowerCase())
+    .filter(Boolean)
+);
+
+/**
+ * Helper indicating whether the supplied username has administrator access
+ * according to the configured allow list. When no allow list exists all
+ * authenticated users are considered administrators.
+ *
+ * @param {string} [username] - Username taken from the session
+ * @returns {boolean} true if the user should be treated as an administrator
+ */
+const userHasAdminAccess = username => {
+  if (!adminUsers.size) return Boolean(username);
+  return Boolean(username && adminUsers.has(username.toLowerCase()));
+};
+
+// Make the current user and a CSRF token available to all templates alongside
+// a convenience flag that indicates if the active session has admin rights.
 app.use((req, res, next) => {
   res.locals.user = req.session.user;
   res.locals.csrfToken = req.csrfToken();
+  const username = req.session.user && req.session.user.username;
+  res.locals.isAdmin = userHasAdminAccess(username);
   next();
 });
 
@@ -252,16 +278,6 @@ const requireAuth = (req, res, next) => {
   res.redirect('/login');
 };
 
-// Build a set of administrator usernames from the ADMIN_USERS environment
-// variable. When empty, all authenticated users are treated as administrators
-// so optional permission checks fall back to simple authentication.
-const adminUsers = new Set(
-  (process.env.ADMIN_USERS || '')
-    .split(',')
-    .map(u => u.trim().toLowerCase())
-    .filter(Boolean)
-);
-
 /**
  * Middleware restricting access to administrator accounts. If no administrators
  * are configured the check is skipped and any authenticated user is allowed.
@@ -269,10 +285,8 @@ const adminUsers = new Set(
  * return a plain 403 page.
  */
 const requireAdmin = (req, res, next) => {
-  if (
-    !adminUsers.size ||
-    (req.session.user && adminUsers.has(req.session.user.username.toLowerCase()))
-  ) {
+  const username = req.session.user && req.session.user.username;
+  if (userHasAdminAccess(username)) {
     return next();
   }
   if (req.headers.accept && req.headers.accept.includes('application/json')) {
@@ -902,17 +916,79 @@ if (enableLogStream) {
   });
 }
 
-// GET /admin - Render the admin interface used for maintenance tasks.
-// Fetch scraping statistics and render the admin page.
-// The dedicated admin page has been removed. Redirect any old links to the
-// scraper page which now hosts all management tools.
-app.get('/admin', requireAuth, (req, res) => {
-  res.redirect('/scraper');
+// GET /admin - Render the consolidated administration console. Only
+// authenticated administrators may access this page because it exposes tools
+// for destructive database actions and account management.
+app.get('/admin', requireAuth, requireAdmin, async (req, res) => {
+  try {
+    const [
+      tenderCount,
+      awardCount,
+      customerCount,
+      supplierCount,
+      lastScraped,
+      tenderBreakdown,
+      users
+    ] = await Promise.all([
+      db.getTenderCount(),
+      db.getAwardCount(),
+      db.getOrganisationCount('customer'),
+      db.getOrganisationCount('supplier'),
+      db.getLastScraped(),
+      db.getTenderCountsBySource(),
+      db.getAllUsers()
+    ]);
+
+    const formattedUsers = users.map(row => ({
+      id: row.id,
+      username: row.username,
+      isAdmin: userHasAdminAccess(row.username)
+    }));
+
+    logger.info('User %s accessed admin console', req.session.user.username);
+
+    res.render('admin', {
+      page: 'admin',
+      counts: {
+        tenders: tenderCount,
+        awards: awardCount,
+        customers: customerCount,
+        suppliers: supplierCount,
+        totalSources: Object.keys(config.sources).length,
+        totalAwardSources: Object.keys(config.awardSources).length,
+        users: formattedUsers.length
+      },
+      lastScraped,
+      tenderBreakdown,
+      users: formattedUsers,
+      cron: config.cronSchedule,
+      adminUsersConfigured: adminUsers.size > 0,
+      adminUsernames: Array.from(adminUsers),
+      currentUser: req.session.user && req.session.user.username
+    });
+  } catch (err) {
+    logger.error('Failed to render admin console:', err);
+    res.status(500).send('Unable to load admin console');
+  }
+});
+
+// Legacy Manage Users page now redirects to the admin console. Non-admin
+// users receive a friendly explanation instead of a blank screen.
+app.get('/manage-users', requireAuth, (req, res) => {
+  const username = req.session.user && req.session.user.username;
+  if (userHasAdminAccess(username)) {
+    return res.redirect('/admin#user-administration');
+  }
+  logger.info(
+    'User %s opened Manage Users without admin rights; showing guidance message',
+    req.session.user.username
+  );
+  res.render('manage-users', { page: 'manage-users' });
 });
 
 // POST /admin/reset-db - Drop and recreate the tenders table. This allows the
 // admin to clear out old data without restarting the server.
-app.post('/admin/reset-db', requireAuth, async (req, res) => {
+app.post('/admin/reset-db', requireAuth, requireAdmin, async (req, res) => {
   try {
     await db.reset();
     res.json({ success: true });
@@ -924,7 +1000,7 @@ app.post('/admin/reset-db', requireAuth, async (req, res) => {
 
 // Remove every tender from the database. Authentication is required so only
 // authorised users can perform destructive actions.
-app.post('/admin/delete-all', requireAuth, async (req, res) => {
+app.post('/admin/delete-all', requireAuth, requireAdmin, async (req, res) => {
   try {
     const summary = await db.deleteAllTenders();
     logger.info(
@@ -946,7 +1022,7 @@ app.post('/admin/delete-all', requireAuth, async (req, res) => {
 });
 
 // Delete tenders older than the supplied date.
-app.post('/admin/delete-before', requireAuth, async (req, res) => {
+app.post('/admin/delete-before', requireAuth, requireAdmin, async (req, res) => {
   const date = req.body && req.body.date;
   if (!date) return res.status(400).json({ error: 'Missing date' });
   try {
@@ -964,11 +1040,33 @@ app.post('/admin/delete-before', requireAuth, async (req, res) => {
 
 // Provide a summary of stored tenders grouped by source. Useful for
 // administrators to inspect database usage.
-app.get('/admin/db-info', requireAuth, async (req, res) => {
+app.get('/admin/db-info', requireAuth, requireAdmin, async (req, res) => {
   try {
-    const counts = await db.getTenderCountsBySource();
-    const total = await db.getTenderCount();
-    res.json({ counts, total });
+    const [
+      counts,
+      total,
+      awardCount,
+      customerCount,
+      supplierCount,
+      lastScraped
+    ] = await Promise.all([
+      db.getTenderCountsBySource(),
+      db.getTenderCount(),
+      db.getAwardCount(),
+      db.getOrganisationCount('customer'),
+      db.getOrganisationCount('supplier'),
+      db.getLastScraped()
+    ]);
+    res.json({
+      counts,
+      total,
+      awardCount,
+      customerCount,
+      supplierCount,
+      lastScraped,
+      sourceCount: Object.keys(config.sources).length,
+      awardSourceCount: Object.keys(config.awardSources).length
+    });
   } catch (err) {
     logger.error('Failed to fetch database info:', err);
     res.status(500).json({ error: 'Failed to fetch data' });
@@ -977,7 +1075,7 @@ app.get('/admin/db-info', requireAuth, async (req, res) => {
 
 // Remove all tenders belonging to the specified source. This allows targeted
 // purging without wiping the entire table.
-app.post('/admin/delete-source', requireAuth, async (req, res) => {
+app.post('/admin/delete-source', requireAuth, requireAdmin, async (req, res) => {
   const source = req.body && req.body.source;
   if (!source) return res.status(400).json({ error: 'Missing source' });
   try {
@@ -992,7 +1090,7 @@ app.post('/admin/delete-source', requireAuth, async (req, res) => {
 
 // POST /admin/cron - Update the cron schedule at runtime. The existing job is
 // stopped and a new one is created using the supplied expression.
-app.post('/admin/cron', requireAuth, async (req, res) => {
+app.post('/admin/cron', requireAuth, requireAdmin, async (req, res) => {
   const schedule = req.body && req.body.schedule;
   if (!schedule || !cron.validate(schedule)) {
     return res.status(400).json({ error: 'Invalid schedule' });
@@ -1005,6 +1103,119 @@ app.post('/admin/cron', requireAuth, async (req, res) => {
   } catch (err) {
     logger.error('Failed to update cron schedule:', err);
     res.status(500).json({ error: 'Failed to update schedule' });
+  }
+});
+
+// -------- User administration ------------------------------------------------
+
+// Fetch a JSON list of all user accounts for the admin interface.
+app.get('/admin/users', requireAuth, requireAdmin, async (req, res) => {
+  try {
+    const users = await db.getAllUsers();
+    res.json({
+      users: users.map(row => ({
+        id: row.id,
+        username: row.username,
+        isAdmin: userHasAdminAccess(row.username)
+      })),
+      adminUsersConfigured: adminUsers.size > 0,
+      adminUsernames: Array.from(adminUsers)
+    });
+  } catch (err) {
+    logger.error('Failed to list users:', err);
+    res.status(500).json({ error: 'Failed to list users' });
+  }
+});
+
+// Create a new user account on behalf of the administrator.
+app.post('/admin/users', requireAuth, requireAdmin, async (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password are required' });
+  }
+  if (password.length < 8) {
+    return res.status(400).json({ error: 'Password must be at least 8 characters' });
+  }
+  try {
+    if (await db.getUserByUsername(username)) {
+      return res.status(409).json({ error: 'Username already exists' });
+    }
+    const hash = await bcrypt.hash(password, 10);
+    await db.createUser(username, hash);
+    const created = await db.getUserByUsername(username);
+    logger.info('Administrator %s created user %s', req.session.user.username, username);
+    res.status(201).json({
+      success: true,
+      user: {
+        id: created.id,
+        username: created.username,
+        isAdmin: userHasAdminAccess(created.username)
+      }
+    });
+  } catch (err) {
+    logger.error('Failed to create user:', err);
+    res.status(500).json({ error: 'Failed to create user' });
+  }
+});
+
+// Update an existing user's password. The password is hashed before storing so
+// the server never exposes plaintext credentials.
+app.patch('/admin/users/:id/password', requireAuth, requireAdmin, async (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (!Number.isInteger(id) || id < 1) {
+    return res.status(400).json({ error: 'Invalid user identifier' });
+  }
+  const { password } = req.body || {};
+  if (!password || password.length < 8) {
+    return res.status(400).json({ error: 'Password must be at least 8 characters' });
+  }
+  try {
+    const userRow = await db.getUserById(id);
+    if (!userRow) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    const hash = await bcrypt.hash(password, 10);
+    await db.updateUserPassword(id, hash);
+    logger.info('Administrator %s reset password for %s', req.session.user.username, userRow.username);
+    res.json({
+      success: true,
+      user: {
+        id: userRow.id,
+        username: userRow.username,
+        isAdmin: userHasAdminAccess(userRow.username)
+      }
+    });
+  } catch (err) {
+    logger.error('Failed to reset password:', err);
+    res.status(500).json({ error: 'Failed to reset password' });
+  }
+});
+
+// Delete a user account. Administrators cannot delete their own session to
+// avoid locking themselves out mid-operation.
+app.delete('/admin/users/:id', requireAuth, requireAdmin, async (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (!Number.isInteger(id) || id < 1) {
+    return res.status(400).json({ error: 'Invalid user identifier' });
+  }
+  try {
+    const userRow = await db.getUserById(id);
+    if (!userRow) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    if (
+      req.session.user &&
+      req.session.user.username &&
+      req.session.user.username.toLowerCase() === userRow.username.toLowerCase()
+    ) {
+      return res.status(400).json({ error: 'You cannot delete the account currently in use' });
+    }
+    await db.deleteUser(id);
+    logger.info('Administrator %s deleted user %s', req.session.user.username, userRow.username);
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('Failed to delete user:', err);
+    res.status(500).json({ error: 'Failed to delete user' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add a dedicated Admin console page with live statistics, database tooling and user management controls
- guard server routes with admin-aware middleware and expose new APIs for listing, creating, updating and deleting users
- extend the SQLite helper with user administration helpers and refresh the navigation, styling and documentation to surface the new console

## Testing
- npm test -- --exit

------
https://chatgpt.com/codex/tasks/task_e_68d15155f4388328b97925664b80c55e