### PR TITLE
Add feed source management to admin console

### DIFF
--- a/frontend/admin-tools.js
+++ b/frontend/admin-tools.js
@@ -1,9 +1,9 @@
 /**
  * @file admin-tools.js
  * @description Client-side controller for the administration console. Handles
- *   destructive database actions, dynamic statistics refreshes and user
- *   management operations with friendly status updates and confirmation
- *   dialogues.
+ *   destructive database actions, dynamic statistics refreshes, feed source
+ *   management and user management operations with friendly status updates and
+ *   confirmation dialogues.
  */
 'use strict';
 
@@ -38,9 +38,27 @@ document.addEventListener('DOMContentLoaded', () => {
     })),
     adminUsersConfigured: Boolean(initial.adminUsersConfigured),
     adminUsernames: initial.adminUsernames || [],
-    currentUser: initial.currentUser || null
+    currentUser: initial.currentUser || null,
+    sources: Object.assign({}, initial.sources || {}),
+    awardSources: Object.assign({}, initial.awardSources || {}),
+    sourceStats: Object.assign({}, initial.sourceStats || {}),
+    sourceStatus: Object.assign({}, initial.sourceStatus || {}),
+    editing: {
+      tender: null,
+      award: null
+    }
   };
   state.counts.users = state.users.length;
+  Object.keys(state.sources || {}).forEach(key => {
+    if (!state.sourceStatus[key]) {
+      state.sourceStatus[key] = 'unknown';
+    }
+  });
+  Object.keys(state.awardSources || {}).forEach(key => {
+    if (!state.sourceStatus[key]) {
+      state.sourceStatus[key] = 'unknown';
+    }
+  });
 
   const csrfMeta = document.querySelector('meta[name="csrf-token"]');
   const csrfToken = csrfMeta ? csrfMeta.content : '';
@@ -59,6 +77,60 @@ document.addEventListener('DOMContentLoaded', () => {
   const passwordUserId = document.getElementById('passwordUserId');
   const passwordInput = document.getElementById('passwordInput');
   const passwordConfirmInput = document.getElementById('passwordConfirmInput');
+  const tenderSourceBody = document.getElementById('tenderSourceTableBody');
+  const awardSourceBody = document.getElementById('awardSourceTableBody');
+  const tenderSourceBanner = document.getElementById('tenderSourceStatus');
+  const awardSourceBanner = document.getElementById('awardSourceStatus');
+  const tenderSourceForm = document.getElementById('tenderSourceForm');
+  const awardSourceForm = document.getElementById('awardSourceForm');
+  const previewDialog = document.getElementById('sourcePreviewDialog');
+  const previewBody = document.getElementById('sourcePreviewBody');
+  const previewSummary = document.getElementById('sourcePreviewSummary');
+  const cancelEditButtons = Array.from(document.querySelectorAll('[data-action="cancel-edit"]'));
+  const formControls = {
+    tender: tenderSourceForm
+      ? {
+          form: tenderSourceForm,
+          inputs: {
+            key: tenderSourceForm.querySelector('input[name="key"]'),
+            label: tenderSourceForm.querySelector('input[name="label"]'),
+            url: tenderSourceForm.querySelector('input[name="url"]'),
+            base: tenderSourceForm.querySelector('input[name="base"]'),
+            parser: tenderSourceForm.querySelector('input[name="parser"]')
+          },
+          submit: tenderSourceForm.querySelector('button[type="submit"]'),
+          cancel: tenderSourceForm.querySelector('[data-action="cancel-edit"]')
+        }
+      : null,
+    award: awardSourceForm
+      ? {
+          form: awardSourceForm,
+          inputs: {
+            key: awardSourceForm.querySelector('input[name="key"]'),
+            label: awardSourceForm.querySelector('input[name="label"]'),
+            url: awardSourceForm.querySelector('input[name="url"]'),
+            base: awardSourceForm.querySelector('input[name="base"]'),
+            parser: awardSourceForm.querySelector('input[name="parser"]')
+          },
+          submit: awardSourceForm.querySelector('button[type="submit"]'),
+          cancel: awardSourceForm.querySelector('[data-action="cancel-edit"]')
+        }
+      : null
+  };
+  const tableBodies = { tender: tenderSourceBody, award: awardSourceBody };
+  const sourceBanners = { tender: tenderSourceBanner, award: awardSourceBanner };
+  const defaultParser = {
+    tender:
+      formControls.tender && formControls.tender.inputs.parser
+        ? formControls.tender.inputs.parser.value || 'contractsFinder'
+        : 'contractsFinder',
+    award:
+      formControls.award && formControls.award.inputs.parser
+        ? formControls.award.inputs.parser.value || 'contractsFinder'
+        : 'contractsFinder'
+  };
+  const apiRoutes = { tender: '/sources', award: '/award-sources' };
+  const testRoutes = { tender: '/test-source', award: '/test-award-source' };
 
   /**
    * Display a status message within the supplied banner element.
@@ -188,9 +260,449 @@ document.addEventListener('DOMContentLoaded', () => {
     userBody.appendChild(fragment);
   }
 
+  function getSourceCollection(kind) {
+    return kind === 'tender' ? state.sources : state.awardSources;
+  }
+
+  function normaliseStatus(value) {
+    return value ? String(value) : 'unknown';
+  }
+
+  function formatTimestamp(value) {
+    if (!value) return 'Never';
+    const dt = new Date(value);
+    if (Number.isNaN(dt.getTime())) {
+      return value;
+    }
+    const date = dt.toLocaleDateString();
+    const time = dt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `${date} ${time}`;
+  }
+
+  function highlightSourceRow(kind, key) {
+    const body = tableBodies[kind];
+    if (!body) return;
+    body.querySelectorAll('tr').forEach(row => row.classList.remove('editing-row'));
+    if (!key) return;
+    const row = body.querySelector(`tr[data-key="${key}"]`);
+    if (row) row.classList.add('editing-row');
+  }
+
+  function renderSourceTable(kind) {
+    const body = tableBodies[kind];
+    if (!body) return;
+    body.innerHTML = '';
+    const entries = Object.entries(getSourceCollection(kind));
+    if (!entries.length) {
+      const empty = document.createElement('tr');
+      empty.className = 'table-empty';
+      const cell = document.createElement('td');
+      cell.colSpan = 7;
+      cell.textContent = 'No sources configured yet.';
+      empty.appendChild(cell);
+      body.appendChild(empty);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    entries
+      .slice()
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .forEach(([key, src]) => {
+        const stats = state.sourceStats[key] || {};
+        const row = document.createElement('tr');
+        row.dataset.key = key;
+        row.dataset.kind = kind;
+        if (state.editing[kind] === key) {
+          row.classList.add('editing-row');
+        }
+
+        const keyCell = document.createElement('td');
+        keyCell.textContent = key;
+
+        const labelCell = document.createElement('td');
+        const labelTitle = document.createElement('div');
+        labelTitle.className = 'source-label';
+        labelTitle.textContent = src && src.label ? src.label : key;
+        labelCell.appendChild(labelTitle);
+        const metaBits = [];
+        if (src && src.base) metaBits.push(src.base);
+        if (src && src.parser) metaBits.push(`Parser: ${src.parser}`);
+        if (metaBits.length) {
+          const meta = document.createElement('div');
+          meta.className = 'source-meta';
+          meta.textContent = metaBits.join(' · ');
+          labelCell.appendChild(meta);
+        }
+
+        const statusCell = document.createElement('td');
+        statusCell.className = 'source-status';
+        statusCell.textContent = normaliseStatus(state.sourceStatus[key]);
+
+        const lastScrapedCell = document.createElement('td');
+        lastScrapedCell.textContent = formatTimestamp(stats.last_scraped);
+
+        const lastAddedCell = document.createElement('td');
+        const lastAdded = typeof stats.last_added === 'number' ? stats.last_added : 0;
+        lastAddedCell.textContent = lastAdded;
+
+        const totalCell = document.createElement('td');
+        const total = typeof stats.total === 'number' ? stats.total : 0;
+        totalCell.textContent = total;
+
+        const actions = document.createElement('td');
+        actions.className = 'source-actions';
+        const testBtn = document.createElement('button');
+        testBtn.type = 'button';
+        testBtn.className = 'secondary source-test';
+        testBtn.textContent = 'Test feed';
+        testBtn.addEventListener('click', () => testSource(kind, key));
+
+        const editBtn = document.createElement('button');
+        editBtn.type = 'button';
+        editBtn.className = 'secondary source-edit';
+        editBtn.textContent = 'Edit';
+        editBtn.addEventListener('click', () => beginSourceEdit(kind, key));
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.type = 'button';
+        deleteBtn.className = 'danger source-delete';
+        deleteBtn.textContent = 'Delete';
+        deleteBtn.addEventListener('click', () => confirmDeleteSource(kind, key));
+
+        actions.append(testBtn, editBtn, deleteBtn);
+
+        row.append(keyCell, labelCell, statusCell, lastScrapedCell, lastAddedCell, totalCell, actions);
+        fragment.appendChild(row);
+      });
+    body.appendChild(fragment);
+  }
+
+  function renderSources() {
+    renderSourceTable('tender');
+    renderSourceTable('award');
+  }
+
+  function resetSourceForm(kind, focus = false) {
+    const control = formControls[kind];
+    if (!control) return;
+    control.form.reset();
+    control.inputs.key.disabled = false;
+    if (control.inputs.parser) {
+      control.inputs.parser.value = defaultParser[kind];
+    }
+    control.submit.textContent = kind === 'tender' ? 'Add source' : 'Add award source';
+    if (control.cancel) {
+      control.cancel.hidden = true;
+    }
+    state.editing[kind] = null;
+    highlightSourceRow(kind, null);
+    if (focus) {
+      control.inputs.key.focus();
+    }
+  }
+
+  function beginSourceEdit(kind, key) {
+    const control = formControls[kind];
+    const collection = getSourceCollection(kind);
+    const data = collection[key];
+    if (!control || !data) return;
+    control.inputs.key.value = key;
+    control.inputs.key.disabled = true;
+    control.inputs.label.value = data.label || '';
+    control.inputs.url.value = data.url || '';
+    control.inputs.base.value = data.base || '';
+    if (control.inputs.parser) {
+      control.inputs.parser.value = data.parser || defaultParser[kind];
+    }
+    control.submit.textContent = kind === 'tender' ? 'Update source' : 'Update award source';
+    if (control.cancel) {
+      control.cancel.hidden = false;
+    }
+    state.editing[kind] = key;
+    highlightSourceRow(kind, key);
+    hideStatus(sourceBanners[kind]);
+  }
+
+  function confirmDeleteSource(kind, key) {
+    const collection = getSourceCollection(kind);
+    const label = collection[key] && collection[key].label ? collection[key].label : key;
+    const typeLabel = kind === 'tender' ? 'tender' : 'award';
+    const confirmed = window.confirm(`Delete ${typeLabel} source "${label}"? This cannot be undone.`);
+    if (!confirmed) return;
+    deleteSource(kind, key);
+  }
+
+  function updateSourceCount(kind, delta) {
+    if (kind === 'tender') {
+      state.counts.totalSources = Math.max(0, (state.counts.totalSources || 0) + delta);
+    } else {
+      state.counts.totalAwardSources = Math.max(0, (state.counts.totalAwardSources || 0) + delta);
+    }
+    updateStatCards();
+  }
+
+  function setRowStatus(kind, key, status) {
+    state.sourceStatus[key] = status;
+    const body = tableBodies[kind];
+    if (!body) return;
+    const row = body.querySelector(`tr[data-key="${key}"]`);
+    if (!row) return;
+    const statusCell = row.querySelector('.source-status');
+    if (statusCell) {
+      statusCell.textContent = normaliseStatus(status);
+    }
+  }
+
+  function openSourcePreview(kind, key, latest, count = 0) {
+    if (!previewDialog || !previewBody || !previewSummary) return;
+    previewBody.innerHTML = '';
+    const collection = getSourceCollection(kind);
+    const label = collection[key] && collection[key].label ? collection[key].label : key;
+    const typeLabel = kind === 'tender' ? 'tender' : 'award';
+    if (count > 0) {
+      previewSummary.textContent = `Showing the newest ${typeLabel} entry from ${label}.`;
+    } else {
+      previewSummary.textContent = `No entries were returned for ${label}. Double-check the feed URL and try again.`;
+    }
+
+    if (!latest) {
+      const message = document.createElement('p');
+      message.textContent = 'No preview was available from that feed.';
+      previewBody.appendChild(message);
+    } else {
+      const title = document.createElement('h4');
+      title.textContent = latest.title || 'Untitled entry';
+      previewBody.appendChild(title);
+
+      if (latest.date) {
+        const date = document.createElement('p');
+        date.className = 'preview-date';
+        date.textContent = formatTimestamp(latest.date);
+        previewBody.appendChild(date);
+      }
+
+      if (latest.link) {
+        const linkPara = document.createElement('p');
+        const link = document.createElement('a');
+        let resolvedLink = latest.link;
+        const baseUrl = collection[key] && collection[key].base;
+        try {
+          resolvedLink = new URL(latest.link, baseUrl || window.location.origin).href;
+        } catch (err) {
+          resolvedLink = latest.link;
+        }
+        link.href = resolvedLink;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = resolvedLink;
+        linkPara.appendChild(link);
+        previewBody.appendChild(linkPara);
+      }
+
+      if (latest.desc) {
+        const desc = document.createElement('p');
+        desc.textContent = latest.desc.replace(/\s+/g, ' ').trim();
+        previewBody.appendChild(desc);
+      }
+    }
+
+    try {
+      previewDialog.showModal();
+    } catch (err) {
+      console.warn('Browser does not support showModal; falling back to open attribute', err);
+      previewDialog.setAttribute('open', 'open');
+    }
+  }
+
+  async function testSource(kind, key) {
+    const collection = getSourceCollection(kind);
+    const label = collection[key] && collection[key].label ? collection[key].label : key;
+    const banner = sourceBanners[kind];
+    hideStatus(banner);
+    setRowStatus(kind, key, 'testing…');
+    announce(banner, `Testing ${kind === 'tender' ? 'tender' : 'award'} source ${label}…`, 'info');
+    try {
+      const res = await fetch(`${testRoutes[kind]}?key=${encodeURIComponent(key)}`, {
+        headers: { Accept: 'application/json' }
+      });
+      const data = await res.json().catch(() => null);
+      if (res.status === 401) {
+        redirectToLogin();
+        return;
+      }
+      if (res.status === 403) {
+        announce(banner, 'Administrator access required to test feeds.', 'error');
+        setRowStatus(kind, key, 'forbidden');
+        return;
+      }
+      if (!res.ok || !data) {
+        const message = (data && (data.error || data.message)) || 'Feed test failed.';
+        announce(banner, message, 'error');
+        setRowStatus(kind, key, 'error');
+        return;
+      }
+      const status = data.status || 'ok';
+      const count = typeof data.count === 'number' ? data.count : 0;
+      setRowStatus(kind, key, status);
+      announce(
+        banner,
+        count
+          ? `Feed responded successfully with ${count} entr${count === 1 ? 'y' : 'ies'}. Preview opened below.`
+          : 'Feed responded successfully but returned no entries.',
+        status === 'ok' ? 'success' : 'info'
+      );
+      openSourcePreview(kind, key, data.latest || null, count);
+    } catch (err) {
+      console.error('Failed to test source', err);
+      announce(banner, 'Unexpected error testing source. See console for details.', 'error');
+      setRowStatus(kind, key, 'error');
+    }
+  }
+
+  async function handleSourceSubmit(kind, evt) {
+    evt.preventDefault();
+    const control = formControls[kind];
+    if (!control) return;
+    hideStatus(sourceBanners[kind]);
+    const keyInput = control.inputs.key.value.trim();
+    const label = control.inputs.label.value.trim();
+    const url = control.inputs.url.value.trim();
+    const base = control.inputs.base.value.trim();
+    const parser = control.inputs.parser
+      ? control.inputs.parser.value.trim() || defaultParser[kind]
+      : defaultParser[kind];
+
+    if (!keyInput || !label || !url || !base) {
+      announce(sourceBanners[kind], 'Please complete every field before saving the feed.', 'info');
+      return;
+    }
+
+    const payload = { key: keyInput, label, url, base, parser };
+    const isUpdate = Boolean(state.editing[kind]);
+    const endpointKey = isUpdate ? state.editing[kind] : keyInput;
+    const endpoint = isUpdate
+      ? `${apiRoutes[kind]}/${encodeURIComponent(endpointKey)}`
+      : apiRoutes[kind];
+    const method = isUpdate ? 'PUT' : 'POST';
+    const typeLabel = kind === 'tender' ? 'tender' : 'award';
+
+    announce(
+      sourceBanners[kind],
+      `${isUpdate ? 'Updating' : 'Creating'} ${typeLabel} source ${label}…`,
+      'info'
+    );
+
+    try {
+      const res = await fetch(endpoint, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'CSRF-Token': csrfToken
+        },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json().catch(() => null);
+      if (res.status === 401) {
+        redirectToLogin();
+        return;
+      }
+      if (res.status === 403) {
+        announce(sourceBanners[kind], 'Administrator access required to modify feeds.', 'error');
+        return;
+      }
+      if (!res.ok || !data || !data.success) {
+        const message = (data && data.error) || 'Failed to save feed configuration.';
+        announce(sourceBanners[kind], message, 'error');
+        return;
+      }
+
+      const saved = data.source || payload;
+      const collection = getSourceCollection(kind);
+      collection[saved.key] = {
+        label: saved.label,
+        url: saved.url,
+        base: saved.base,
+        parser: saved.parser
+      };
+      state.sourceStatus[saved.key] = 'unknown';
+      if (!state.sourceStats[saved.key]) {
+        state.sourceStats[saved.key] = { last_scraped: null, last_added: 0, total: 0 };
+      }
+      if (!isUpdate) {
+        updateSourceCount(kind, 1);
+      }
+      renderSourceTable(kind);
+      resetSourceForm(kind, true);
+      announce(
+        sourceBanners[kind],
+        `${isUpdate ? 'Updated' : 'Added'} ${typeLabel} source ${saved.label || saved.key}.`,
+        'success'
+      );
+    } catch (err) {
+      console.error('Failed to save source', err);
+      announce(sourceBanners[kind], 'Unexpected error saving feed configuration.', 'error');
+    }
+  }
+
+  async function deleteSource(kind, key) {
+    const collection = getSourceCollection(kind);
+    const label = collection[key] && collection[key].label ? collection[key].label : key;
+    const banner = sourceBanners[kind];
+    hideStatus(banner);
+    announce(banner, `Deleting ${kind === 'tender' ? 'tender' : 'award'} source ${label}…`, 'info');
+    try {
+      const res = await fetch(`${apiRoutes[kind]}/${encodeURIComponent(key)}`, {
+        method: 'DELETE',
+        headers: { Accept: 'application/json', 'CSRF-Token': csrfToken }
+      });
+      const data = await res.json().catch(() => null);
+      if (res.status === 401) {
+        redirectToLogin();
+        return;
+      }
+      if (res.status === 403) {
+        announce(banner, 'Administrator access required to delete feeds.', 'error');
+        return;
+      }
+      if (!res.ok || !data || !data.success) {
+        const message = (data && data.error) || 'Failed to delete feed configuration.';
+        announce(banner, message, 'error');
+        return;
+      }
+      delete collection[key];
+      delete state.sourceStatus[key];
+      delete state.sourceStats[key];
+      if (state.editing[kind] === key) {
+        resetSourceForm(kind, false);
+      }
+      updateSourceCount(kind, -1);
+      renderSourceTable(kind);
+      announce(banner, `${label} removed.`, 'success');
+    } catch (err) {
+      console.error('Failed to delete source', err);
+      announce(banner, 'Unexpected error deleting feed configuration.', 'error');
+    }
+  }
+
   updateStatCards();
   renderTenderBreakdown();
   renderUsers();
+  renderSources();
+
+  if (formControls.tender) {
+    formControls.tender.form.addEventListener('submit', evt => handleSourceSubmit('tender', evt));
+  }
+  if (formControls.award) {
+    formControls.award.form.addEventListener('submit', evt => handleSourceSubmit('award', evt));
+  }
+  cancelEditButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const kind = btn.dataset.kind === 'award' ? 'award' : 'tender';
+      resetSourceForm(kind, true);
+    });
+  });
 
   function redirectToLogin() {
     window.location.href = '/login';

--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -8,8 +8,9 @@
     1. Page header and navigation tabs.
     2. Summary cards showing live system metrics.
     3. Database tools for wiping or inspecting stored data.
-    4. User administration area for creating, resetting and deleting accounts.
-    5. Lightweight dialog components for confirmations and password updates.
+    4. Feed source management area for creating, updating and testing tender and award feeds.
+    5. User administration area for creating, resetting and deleting accounts.
+    6. Lightweight dialog components for confirmations, password updates and feed previews.
 -->
 <!DOCTYPE html>
 <html>
@@ -108,6 +109,149 @@
     </table>
   </section>
 
+  <section id="source-admin" class="panel" aria-labelledby="source-admin-heading">
+    <div class="panel-header">
+      <h2 id="source-admin-heading">Feed source management</h2>
+      <p>Configure which tender and award feeds are scraped. Every change is
+        logged and applied immediately, so double-check entries before saving.</p>
+    </div>
+    <p class="hint">Testing a feed fetches the most recent entry and displays it
+      in a pop-up so you can confirm the data looks correct.</p>
+    <div class="instruction-card" role="note" aria-labelledby="source-instructions-title">
+      <h3 id="source-instructions-title">Checklist before saving a feed</h3>
+      <ol class="instruction-list">
+        <li>Choose a unique <strong>Key</strong> using letters, numbers or dashes.
+          This identifier appears in logs and statistics.</li>
+        <li>Enter a clear <strong>Label</strong> so colleagues recognise the feed.</li>
+        <li>Paste the full <strong>Search or RSS URL</strong> that lists the newest
+          notices you need to track.</li>
+        <li>Provide the site <strong>Base URL</strong> (for example
+          <code>https://www.contractsfinder.service.gov.uk</code>). Links in the
+          feed are resolved against this value.</li>
+        <li>Leave the <strong>Parser</strong> as <code>contractsFinder</code> unless
+          the feed requires a bespoke parser. Documentation for available parsers
+          lives on the Help page.</li>
+      </ol>
+    </div>
+    <div class="source-columns">
+      <article class="source-column" aria-labelledby="tender-sources-heading">
+        <h3 id="tender-sources-heading">Tender sources</h3>
+        <p class="hint">These feeds supply the Opportunities page.</p>
+        <div id="tenderSourceStatus" class="status-banner" role="status" aria-live="polite" hidden></div>
+        <table class="source-table" aria-describedby="tender-sources-heading">
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              <th scope="col">Label</th>
+              <th scope="col">Status</th>
+              <th scope="col">Last scraped</th>
+              <th scope="col">New items (last run)</th>
+              <th scope="col">Total stored</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="tenderSourceTableBody">
+            <tr class="table-empty"><td colspan="7">Sources load automatically once the page initialises.</td></tr>
+          </tbody>
+        </table>
+        <form id="tenderSourceForm" class="source-form" autocomplete="off" data-kind="tender">
+          <fieldset>
+            <legend class="visually-hidden">Create or update a tender source</legend>
+            <div class="form-grid">
+              <div class="form-field">
+                <label for="tenderSourceKey">Key</label>
+                <input id="tenderSourceKey" name="key" type="text" pattern="[a-zA-Z0-9-]+" required autocomplete="off">
+                <span class="form-hint">Letters, numbers and dashes only.</span>
+              </div>
+              <div class="form-field">
+                <label for="tenderSourceLabel">Label</label>
+                <input id="tenderSourceLabel" name="label" type="text" required autocomplete="off">
+                <span class="form-hint">Shown to end users and in reports.</span>
+              </div>
+              <div class="form-field">
+                <label for="tenderSourceUrl">Search or RSS URL</label>
+                <input id="tenderSourceUrl" name="url" type="url" required placeholder="https://example.com/search?q=...">
+                <span class="form-hint">Must return the newest tenders.</span>
+              </div>
+              <div class="form-field">
+                <label for="tenderSourceBase">Base URL</label>
+                <input id="tenderSourceBase" name="base" type="url" required placeholder="https://example.com">
+                <span class="form-hint">Homepage used to resolve relative links.</span>
+              </div>
+              <div class="form-field">
+                <label for="tenderSourceParser">Parser</label>
+                <input id="tenderSourceParser" name="parser" type="text" value="contractsFinder" autocomplete="off">
+                <span class="form-hint">Advanced: override only if instructed.</span>
+              </div>
+            </div>
+            <div class="form-actions">
+              <button type="submit" id="tenderSourceSubmit">Add source</button>
+              <button type="button" class="secondary" data-action="cancel-edit" data-kind="tender" hidden>Cancel editing</button>
+            </div>
+          </fieldset>
+        </form>
+      </article>
+
+      <article class="source-column" aria-labelledby="award-sources-heading">
+        <h3 id="award-sources-heading">Award sources</h3>
+        <p class="hint">These feeds populate the Awarded Contracts page.</p>
+        <div id="awardSourceStatus" class="status-banner" role="status" aria-live="polite" hidden></div>
+        <table class="source-table" aria-describedby="award-sources-heading">
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              <th scope="col">Label</th>
+              <th scope="col">Status</th>
+              <th scope="col">Last scraped</th>
+              <th scope="col">New items (last run)</th>
+              <th scope="col">Total stored</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="awardSourceTableBody">
+            <tr class="table-empty"><td colspan="7">Award feeds load automatically once the page initialises.</td></tr>
+          </tbody>
+        </table>
+        <form id="awardSourceForm" class="source-form" autocomplete="off" data-kind="award">
+          <fieldset>
+            <legend class="visually-hidden">Create or update an award source</legend>
+            <div class="form-grid">
+              <div class="form-field">
+                <label for="awardSourceKey">Key</label>
+                <input id="awardSourceKey" name="key" type="text" pattern="[a-zA-Z0-9-]+" required autocomplete="off">
+                <span class="form-hint">Letters, numbers and dashes only.</span>
+              </div>
+              <div class="form-field">
+                <label for="awardSourceLabel">Label</label>
+                <input id="awardSourceLabel" name="label" type="text" required autocomplete="off">
+                <span class="form-hint">Shown to end users and in reports.</span>
+              </div>
+              <div class="form-field">
+                <label for="awardSourceUrl">Search or RSS URL</label>
+                <input id="awardSourceUrl" name="url" type="url" required placeholder="https://example.com/feed">
+                <span class="form-hint">Should list the newest award notices.</span>
+              </div>
+              <div class="form-field">
+                <label for="awardSourceBase">Base URL</label>
+                <input id="awardSourceBase" name="base" type="url" required placeholder="https://example.com">
+                <span class="form-hint">Homepage used to resolve relative links.</span>
+              </div>
+              <div class="form-field">
+                <label for="awardSourceParser">Parser</label>
+                <input id="awardSourceParser" name="parser" type="text" value="contractsFinder" autocomplete="off">
+                <span class="form-hint">Advanced: override only if instructed.</span>
+              </div>
+            </div>
+            <div class="form-actions">
+              <button type="submit" id="awardSourceSubmit">Add award source</button>
+              <button type="button" class="secondary" data-action="cancel-edit" data-kind="award" hidden>Cancel editing</button>
+            </div>
+          </fieldset>
+        </form>
+      </article>
+    </div>
+  </section>
+
   <section id="user-administration" class="panel" aria-labelledby="user-admin-heading">
     <div class="panel-header">
       <h2 id="user-admin-heading">User administration</h2>
@@ -180,6 +324,18 @@
     </form>
   </dialog>
 
+  <dialog id="sourcePreviewDialog" aria-labelledby="sourcePreviewTitle">
+    <form id="sourcePreviewForm" method="dialog">
+      <h3 id="sourcePreviewTitle">Latest feed item</h3>
+      <p id="sourcePreviewSummary" class="hint">Use the Test button beside a
+        feed to display a preview of the newest entry.</p>
+      <article id="sourcePreviewBody" class="preview-body" aria-live="polite"></article>
+      <div class="dialog-actions">
+        <button type="submit">Close</button>
+      </div>
+    </form>
+  </dialog>
+
   <script id="adminData" type="application/json"><%- JSON.stringify({
     counts,
     lastScraped,
@@ -188,7 +344,11 @@
     cron,
     adminUsersConfigured,
     adminUsernames,
-    currentUser
+    currentUser,
+    sources,
+    awardSources,
+    sourceStats,
+    sourceStatus
   }).replace(/</g, '\\u003c') %></script>
   <script type="module" src="/admin-tools.js"></script>
 </body>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5,7 +5,8 @@
  * Sections:
  *   1. Base typography and table styling.
  *   2. Utility components such as instructions, pagination and tabs.
- *   3. Modal presentation used for raw tender payload viewing.
+ *   3. Administration panels and form layouts.
+ *   4. Feed management enhancements and preview dialog helpers.
  */
 
 /* Base typography and colours */
@@ -196,6 +197,132 @@ button:hover {
   border-radius: 8px;
   padding: 1.25rem;
   box-shadow: 0 4px 14px rgba(15, 23, 42, 0.05);
+}
+
+.instruction-card {
+  background: #e7f5ff;
+  border: 1px solid #b6e0fe;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+}
+
+.instruction-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: #0f172a;
+}
+
+.instruction-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  line-height: 1.5;
+}
+
+.instruction-list li {
+  margin-bottom: 0.35rem;
+}
+
+.source-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.source-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.source-form {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06);
+}
+
+.source-form fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.source-form legend {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
+.source-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.source-actions button {
+  flex: 0 1 auto;
+}
+
+.source-label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.source-meta {
+  font-size: 0.85rem;
+  color: #6c757d;
+  margin-top: 0.2rem;
+}
+
+.editing-row {
+  outline: 2px solid #1d4ed8;
+  outline-offset: -2px;
+  background: #eef2ff;
+}
+
+.preview-body {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.preview-body h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1d4ed8;
+}
+
+.preview-date {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #6c757d;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .panel-header {

--- a/server/index.js
+++ b/server/index.js
@@ -592,11 +592,13 @@ app.post('/sources', requireAuth, async (req, res) => {
     // Store the new source definition then add it to the in-memory object used
     // by the rest of the application.
     await db.insertSource(key, label, url, base, parser);
-    config.sources[key] = { label, url, base, parser };
+    const record = { label, url, base, parser };
+    config.sources[key] = record;
+    sourceStatus[key] = 'unknown';
     // Persist the updated configuration so custom sources survive restarts.
     sourceStore.save();
     logger.info(`Added new source ${key}: ${label}`);
-    res.json({ success: true });
+    res.json({ success: true, source: { key, ...record } });
   } catch (err) {
     logger.error('Failed to persist source:', err);
     res.status(500).json({ error: 'Failed to save source' });
@@ -627,11 +629,13 @@ app.put('/sources/:key', requireAuth, async (req, res) => {
 
   try {
     await db.updateSource(key, label, url, base, parser);
-    config.sources[key] = { label, url, base, parser };
+    const record = { label, url, base, parser };
+    config.sources[key] = record;
+    sourceStatus[key] = 'unknown';
     // Persist changes so they are reloaded on the next start.
     sourceStore.save();
     logger.info(`Updated source ${key}: ${label}`);
-    res.json({ success: true });
+    res.json({ success: true, source: { key, ...record } });
   } catch (err) {
     logger.error('Failed to update source:', err);
     res.status(500).json({ error: 'Failed to update source' });
@@ -648,10 +652,11 @@ app.delete('/sources/:key', requireAuth, async (req, res) => {
   try {
     await db.deleteSource(key);
     delete config.sources[key];
+    delete sourceStatus[key];
     // Save the remaining sources for persistence.
     sourceStore.save();
     logger.info(`Deleted source ${key}`);
-    res.json({ success: true });
+    res.json({ success: true, key });
   } catch (err) {
     logger.error('Failed to delete source:', err);
     res.status(500).json({ error: 'Failed to delete source' });
@@ -681,11 +686,13 @@ app.post('/award-sources', requireAuth, async (req, res) => {
 
   try {
     await db.insertAwardSource(key, label, url, base, parser);
-    config.awardSources[key] = { label, url, base, parser };
+    const record = { label, url, base, parser };
+    config.awardSources[key] = record;
+    sourceStatus[key] = 'unknown';
     // Ensure award source changes survive server restarts.
     sourceStore.save();
     logger.info(`Added new award source ${key}: ${label}`);
-    res.json({ success: true });
+    res.json({ success: true, source: { key, ...record } });
   } catch (err) {
     logger.error('Failed to save award source:', err);
     res.status(500).json({ error: 'Failed to save source' });
@@ -714,11 +721,13 @@ app.put('/award-sources/:key', requireAuth, async (req, res) => {
 
   try {
     await db.updateAwardSource(key, label, url, base, parser);
-    config.awardSources[key] = { label, url, base, parser };
+    const record = { label, url, base, parser };
+    config.awardSources[key] = record;
+    sourceStatus[key] = 'unknown';
     // Persist the updated award sources list.
     sourceStore.save();
     logger.info(`Updated award source ${key}: ${label}`);
-    res.json({ success: true });
+    res.json({ success: true, source: { key, ...record } });
   } catch (err) {
     logger.error('Failed to update award source:', err);
     res.status(500).json({ error: 'Failed to update source' });
@@ -734,10 +743,11 @@ app.delete('/award-sources/:key', requireAuth, async (req, res) => {
   try {
     await db.deleteAwardSource(key);
     delete config.awardSources[key];
+    delete sourceStatus[key];
     // Keep JSON file in sync after deletion.
     sourceStore.save();
     logger.info(`Deleted award source ${key}`);
-    res.json({ success: true });
+    res.json({ success: true, key });
   } catch (err) {
     logger.error('Failed to delete award source:', err);
     res.status(500).json({ error: 'Failed to delete source' });
@@ -757,7 +767,8 @@ app.get('/test-source', requireAuth, async (req, res) => {
     const html = await r.text();
     const tenders = parseTenders(html, src);
     sourceStatus[key] = 'ok';
-    res.json({ status: 'ok', count: tenders.length });
+    const latest = tenders[0] || null;
+    res.json({ status: 'ok', count: tenders.length, latest });
   } catch (err) {
     sourceStatus[key] = 'error';
     res.status(500).json({ status: 'error', message: err.message });
@@ -774,7 +785,8 @@ app.get('/test-award-source', requireAuth, async (req, res) => {
     const html = await r.text();
     const tenders = parseTenders(html, src);
     sourceStatus[key] = 'ok';
-    res.json({ status: 'ok', count: tenders.length });
+    const latest = tenders[0] || null;
+    res.json({ status: 'ok', count: tenders.length, latest });
   } catch (err) {
     sourceStatus[key] = 'error';
     res.status(500).json({ status: 'error', message: err.message });
@@ -928,7 +940,8 @@ app.get('/admin', requireAuth, requireAdmin, async (req, res) => {
       supplierCount,
       lastScraped,
       tenderBreakdown,
-      users
+      users,
+      sourceStatsRows
     ] = await Promise.all([
       db.getTenderCount(),
       db.getAwardCount(),
@@ -936,8 +949,14 @@ app.get('/admin', requireAuth, requireAdmin, async (req, res) => {
       db.getOrganisationCount('supplier'),
       db.getLastScraped(),
       db.getTenderCountsBySource(),
-      db.getAllUsers()
+      db.getAllUsers(),
+      db.getSourceStats()
     ]);
+
+    const sourceStats = {};
+    for (const row of sourceStatsRows) {
+      sourceStats[row.key] = row;
+    }
 
     const formattedUsers = users.map(row => ({
       id: row.id,
@@ -964,7 +983,11 @@ app.get('/admin', requireAuth, requireAdmin, async (req, res) => {
       cron: config.cronSchedule,
       adminUsersConfigured: adminUsers.size > 0,
       adminUsernames: Array.from(adminUsers),
-      currentUser: req.session.user && req.session.user.username
+      currentUser: req.session.user && req.session.user.username,
+      sources: config.sources,
+      awardSources: config.awardSources,
+      sourceStats,
+      sourceStatus
     });
   } catch (err) {
     logger.error('Failed to render admin console:', err);


### PR DESCRIPTION
## Summary
- add a feed management panel to the admin console with step-by-step guidance, editable tables for tender and award sources, and a preview dialog for test results
- extend the admin client controller to support CRUD operations, inline validation, status messaging, and latest-item previews when testing feeds
- update server endpoints to return structured source data, reset runtime status, and expose latest feed entries to the UI

## Testing
- npm test -- --exit

------
https://chatgpt.com/codex/tasks/task_e_68dd27a367ec8328a065b95516102984