### PR TITLE
Add CPV explorer and tender filtering dashboard

### DIFF
--- a/frontend/cpv-browser.js
+++ b/frontend/cpv-browser.js
@@ -1,0 +1,237 @@
+/*
+ * File: cpv-browser.js
+ * Overview: Client-side controller for the CPV explorer tab. Handles search
+ *   requests against the CPV catalogue, renders paginated results and manages
+ *   the user's session-based favourites list.
+ * Structure:
+ *   - Initialises UI references and local state from window.__CPV_PREFILL__.
+ *   - Provides debounced search logic with pagination.
+ *   - Synchronises favourite selections with the Express session API.
+ */
+(function () {
+  const prefill = window.__CPV_PREFILL__ || {};
+  const favouritesList = document.getElementById('cpvFavouritesList');
+  const favouritesEmpty = document.getElementById('cpvFavouritesEmpty');
+  const resultsBody = document.getElementById('cpvResultsBody');
+  const searchInput = document.getElementById('cpvSearchInput');
+  const statusEl = document.getElementById('cpvSearchStatus');
+  const pageInfo = document.getElementById('cpvPageInfo');
+  const prevBtn = document.getElementById('cpvPrevPage');
+  const nextBtn = document.getElementById('cpvNextPage');
+
+  const state = {
+    page: 1,
+    pageSize: 25,
+    total: 0,
+    query: ''
+  };
+
+  const favourites = new Map();
+  (prefill.favourites || []).forEach(entry => {
+    if (!entry || typeof entry.code !== 'string') return;
+    const code = entry.code.trim();
+    if (!/^[0-9]{8}$/.test(code)) return;
+    favourites.set(code, entry.description || '');
+  });
+
+  function updateFavouritesUI() {
+    favouritesList.innerHTML = '';
+    if (!favourites.size) {
+      favouritesEmpty.classList.remove('hidden');
+      return;
+    }
+    favouritesEmpty.classList.add('hidden');
+    const fragment = document.createDocumentFragment();
+    favourites.forEach((description, code) => {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${code}</strong> — ${description || 'No description available'}`;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = 'Remove';
+      button.classList.add('outline');
+      button.addEventListener('click', () => modifyFavourite(code, description, false));
+      li.appendChild(button);
+      fragment.appendChild(li);
+    });
+    favouritesList.appendChild(fragment);
+  }
+
+  function renderResults(results) {
+    resultsBody.innerHTML = '';
+    if (!results.length) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 3;
+      cell.textContent = 'No CPV codes matched the current search terms.';
+      row.appendChild(cell);
+      resultsBody.appendChild(row);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    results.forEach(result => {
+      const row = document.createElement('tr');
+      const codeCell = document.createElement('td');
+      codeCell.textContent = result.code;
+      const descCell = document.createElement('td');
+      descCell.textContent = result.description || 'No description provided.';
+      const favCell = document.createElement('td');
+      const isFav = favourites.has(result.code);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = isFav ? '★ Remove' : '☆ Favourite';
+      button.setAttribute('aria-pressed', isFav ? 'true' : 'false');
+      button.addEventListener('click', () => modifyFavourite(result.code, result.description, !isFav));
+      favCell.appendChild(button);
+      row.append(codeCell, descCell, favCell);
+      fragment.appendChild(row);
+    });
+    resultsBody.appendChild(fragment);
+  }
+
+  function updateStatus(message) {
+    statusEl.textContent = message;
+  }
+
+  function updatePagination() {
+    const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+    pageInfo.textContent = `Page ${state.page} of ${totalPages}`;
+    prevBtn.disabled = state.page <= 1;
+    nextBtn.disabled = state.page >= totalPages;
+  }
+
+  async function loadFavourites() {
+    try {
+      const response = await fetch('/api/cpv-favourites', {
+        headers: { Accept: 'application/json' }
+      });
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const payload = await response.json();
+      if (Array.isArray(payload.favourites)) {
+        favourites.clear();
+        payload.favourites.forEach(entry => {
+          if (!entry || typeof entry.code !== 'string') return;
+          const code = entry.code.trim();
+          if (!/^[0-9]{8}$/.test(code)) return;
+          favourites.set(code, entry.description || '');
+        });
+        updateFavouritesUI();
+      }
+    } catch (err) {
+      console.error('Failed to load CPV favourites', err);
+      updateStatus('Unable to load favourites from the server.');
+    }
+  }
+
+  let searchTimer = null;
+  let latestSearchId = 0;
+
+  async function performSearch() {
+    const requestId = ++latestSearchId;
+    const params = new URLSearchParams({
+      search: state.query,
+      page: String(state.page),
+      limit: String(state.pageSize)
+    });
+    updateStatus('Searching the CPV catalogue…');
+    try {
+      const response = await fetch(`/api/cpv-codes?${params.toString()}`, {
+        headers: { Accept: 'application/json' }
+      });
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const payload = await response.json();
+      if (requestId !== latestSearchId) {
+        return;
+      }
+      state.total = payload.total || 0;
+      const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+      if (state.page > totalPages) {
+        state.page = totalPages;
+        updatePagination();
+        performSearch();
+        return;
+      }
+      renderResults(payload.results || []);
+      updatePagination();
+      if (payload.results && payload.results.length) {
+        updateStatus(`Displaying ${payload.results.length} codes (of ${payload.total || 0}).`);
+      } else {
+        updateStatus('No CPV entries matched the current search.');
+      }
+    } catch (err) {
+      console.error('CPV search failed', err);
+      if (requestId !== latestSearchId) return;
+      updateStatus('Unable to query the CPV catalogue. Please try again shortly.');
+    }
+  }
+
+  async function modifyFavourite(code, description, shouldAdd) {
+    try {
+      const payload = {
+        code,
+        action: shouldAdd ? 'add' : 'remove'
+      };
+      if (shouldAdd) {
+        payload.description = description || '';
+      }
+      const response = await fetch('/api/cpv-favourites', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+      const json = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(json.error || `Server responded with ${response.status}`);
+      }
+      favourites.clear();
+      (json.favourites || []).forEach(entry => {
+        if (!entry || typeof entry.code !== 'string') return;
+        const favCode = entry.code.trim();
+        if (!/^[0-9]{8}$/.test(favCode)) return;
+        favourites.set(favCode, entry.description || '');
+      });
+      updateFavouritesUI();
+      performSearch();
+    } catch (err) {
+      console.error('Failed to update favourite state', err);
+      updateStatus(err.message || 'Unable to update favourites.');
+    }
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', () => {
+      if (searchTimer) {
+        clearTimeout(searchTimer);
+      }
+      searchTimer = setTimeout(() => {
+        state.page = 1;
+        state.query = searchInput.value.trim();
+        performSearch();
+      }, 250);
+    });
+  }
+
+  prevBtn.addEventListener('click', () => {
+    if (state.page > 1) {
+      state.page -= 1;
+      performSearch();
+    }
+  });
+
+  nextBtn.addEventListener('click', () => {
+    const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+    if (state.page < totalPages) {
+      state.page += 1;
+      performSearch();
+    }
+  });
+
+  updateFavouritesUI();
+  loadFavourites().then(() => performSearch());
+})();

--- a/frontend/cpv.ejs
+++ b/frontend/cpv.ejs
@@ -1,0 +1,71 @@
+<!--
+  File: cpv.ejs
+  Overview: Dedicated CPV explorer allowing users to browse the 2008 CPV
+    catalogue bundled with the repository. The page provides an interactive
+    search experience plus per-session favourites for quick reference.
+  Structure:
+    - Navigation header and headline instructions.
+    - Favourites summary showcasing saved CPV codes.
+    - Search form with results table powered by cpv-browser.js.
+  Behaviour:
+    - Fetches CPV data from /api/cpv-codes and favourites from /api/cpv-favourites.
+    - Allows codes to be added/removed from the session favourites list.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CPV Explorer</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>CPV Explorer</h1>
+  <%- include('partials/nav', { page: 'cpv', user: user }) %>
+  <div id="instructions">
+    <strong>How to use this page:</strong>
+    <ul>
+      <li>Search the official CPV hierarchy using full or partial keywords.</li>
+      <li>Click the star button beside any code to add it to your favourites list for later.</li>
+      <li>Favourite codes appear both here and on the Tenders tab for rapid filtering.</li>
+    </ul>
+  </div>
+  <% if (loadError) { %>
+    <div class="status-banner error"><%= loadError %></div>
+  <% } %>
+  <section class="panel">
+    <h2>Your favourite CPV codes</h2>
+    <p class="panel-text">Favourite codes are stored in your browser session so you can re-use them while investigating opportunities.</p>
+    <ul id="cpvFavouritesList" class="cpv-favourites"></ul>
+    <p id="cpvFavouritesEmpty" class="form-hint">No favourites yet. Use the search below to bookmark the codes you care about.</p>
+  </section>
+  <section class="panel">
+    <h2>Search the CPV catalogue</h2>
+    <form id="cpvSearchForm" class="cpv-search" role="search">
+      <label for="cpvSearchInput">Keywords or code</label>
+      <input id="cpvSearchInput" type="search" placeholder="E.g. software development" autocomplete="off">
+      <p class="form-hint">Search terms match both CPV codes and their English descriptions. Results update automatically as you type.</p>
+    </form>
+    <div id="cpvSearchStatus" class="form-hint" aria-live="polite"></div>
+    <table id="cpvResultsTable">
+      <thead>
+        <tr>
+          <th scope="col">CPV code</th>
+          <th scope="col">Description</th>
+          <th scope="col">Favourite</th>
+        </tr>
+      </thead>
+      <tbody id="cpvResultsBody"></tbody>
+    </table>
+    <div id="cpvPagination" class="pagination">
+      <button type="button" id="cpvPrevPage" aria-label="Previous results">Previous</button>
+      <span id="cpvPageInfo"></span>
+      <button type="button" id="cpvNextPage" aria-label="Next results">Next</button>
+    </div>
+  </section>
+  <script>
+    window.__CPV_PREFILL__ = {
+      favourites: <%- JSON.stringify(favourites || []) %>
+    };
+  </script>
+  <script src="/cpv-browser.js"></script>
+</body>
+</html>

--- a/frontend/partials/nav.ejs
+++ b/frontend/partials/nav.ejs
@@ -11,6 +11,8 @@
 <ul class="tabs">
   <li class="<%= page === 'dashboard' ? 'active' : '' %>"><a href="/dashboard">Dashboard</a></li>
   <li class="<%= page === 'opportunities' ? 'active' : '' %>"><a href="/opportunities">Opportunities</a></li>
+  <li class="<%= page === 'tenders' ? 'active' : '' %>"><a href="/tenders">Tenders</a></li>
+  <li class="<%= page === 'cpv' ? 'active' : '' %>"><a href="/cpv">CPV Explorer</a></li>
   <li class="<%= page === 'awarded' ? 'active' : '' %>"><a href="/awarded">Awarded</a></li>
   <li class="<%= page === 'scraper' ? 'active' : '' %>"><a href="/scraper">Scraper</a></li>
   <li class="<%= page === 'crm' ? 'active' : '' %>"><a href="/crm">CRM</a></li>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -514,6 +514,178 @@ button.danger:hover {
   margin: 0 0.25rem;
 }
 
+/* Panel layout reused by the CPV and Tender explorer interfaces */
+.panel {
+  margin-top: 1rem;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.panel h2 {
+  margin-top: 0;
+}
+
+.tender-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem 1rem;
+  align-items: center;
+}
+
+.filter-grid label {
+  font-weight: 600;
+}
+
+.filter-grid input,
+.filter-grid select {
+  width: 100%;
+  padding: 0.45rem;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.multiselect {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  background: #f8f9fa;
+  min-height: 42px;
+}
+
+.multiselect__option {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.multiselect__option input {
+  margin: 0;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+button.outline {
+  background: transparent;
+  border: 1px solid #0d6efd;
+  color: #0d6efd;
+}
+
+button.outline:hover {
+  background: #e7f1ff;
+}
+
+.table-subtext {
+  font-size: 0.85em;
+  color: #495057;
+  margin-top: 0.25rem;
+}
+
+.cpv-mode {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.cpv-filter-favourites {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.cpv-filter-favourites button {
+  padding: 0.35rem 0.75rem;
+}
+
+.cpv-filter-favourites button.active {
+  background: #0d6efd;
+  color: #fff;
+  border-color: #0d6efd;
+}
+
+.cpv-suggestions {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cpv-suggestion {
+  text-align: left;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  background: #f1f3f5;
+}
+
+.cpv-selected {
+  list-style: none;
+  margin: 0.75rem 0 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cpv-selected li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  background: #f8f9fa;
+  padding: 0.5rem 0.75rem;
+}
+
+.cpv-selected li button {
+  margin-left: auto;
+}
+
+.cpv-favourites {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cpv-favourites li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.cpv-search input,
+#cpvSearchInput {
+  width: 100%;
+  max-width: 480px;
+}
+
 /* Pagination used for server-side pages mirrors the table controls */
 .server-pagination {
   margin-top: 0.5rem;

--- a/frontend/tenders-hub.js
+++ b/frontend/tenders-hub.js
@@ -1,0 +1,481 @@
+/*
+ * File: tenders-hub.js
+ * Overview: Client-side coordinator for the Tenders explorer. It wires filter
+ *   controls to the /api/tenders endpoint, provides CPV-assisted filtering and
+ *   renders a paginated results table.
+ * Structure:
+ *   - Builds UI components (source checkboxes, CPV favourites, suggestions).
+ *   - Maintains a state object representing the active filters.
+ *   - Fetches tender data and updates pagination/status text.
+ */
+(function () {
+  const prefill = window.__TENDER_PREFILL__ || {};
+  const sources = Array.isArray(prefill.sources) ? prefill.sources : [];
+  const favouriteCpv = Array.isArray(prefill.favourites) ? prefill.favourites : [];
+
+  const searchInput = document.getElementById('tenderSearch');
+  const sourceContainer = document.getElementById('sourceSelect');
+  const scrapedFromInput = document.getElementById('scrapedFrom');
+  const scrapedToInput = document.getElementById('scrapedTo');
+  const openFromInput = document.getElementById('openFrom');
+  const openToInput = document.getElementById('openTo');
+  const closeFromInput = document.getElementById('closeFrom');
+  const closeToInput = document.getElementById('closeTo');
+  const sortField = document.getElementById('sortField');
+  const sortDirection = document.getElementById('sortDirection');
+  const applyBtn = document.getElementById('applyFilters');
+  const resetBtn = document.getElementById('resetFilters');
+  const tenderStatus = document.getElementById('tenderStatus');
+  const tableBody = document.getElementById('tendersTableBody');
+  const pageInfo = document.getElementById('tenderPageInfo');
+  const prevBtn = document.getElementById('tenderPrev');
+  const nextBtn = document.getElementById('tenderNext');
+  const cpvModeInputs = document.querySelectorAll('input[name="cpvMode"]');
+  const cpvFavouriteContainer = document.getElementById('cpvFilterFavourites');
+  const cpvSearchInput = document.getElementById('cpvFilterSearch');
+  const cpvSuggestions = document.getElementById('cpvFilterSuggestions');
+  const cpvSelectionList = document.getElementById('cpvFilterSelection');
+
+  const state = {
+    page: 1,
+    pageSize: 25,
+    total: 0,
+    query: '',
+    sources: new Set(),
+    scrapedFrom: null,
+    scrapedTo: null,
+    openFrom: null,
+    openTo: null,
+    closeFrom: null,
+    closeTo: null,
+    cpv: new Map(),
+    cpvMode: 'or',
+    sort: 'scraped_at',
+    direction: 'desc'
+  };
+
+  function renderSourceOptions() {
+    if (!sourceContainer) return;
+    sourceContainer.innerHTML = '';
+    if (!sources.length) {
+      const empty = document.createElement('p');
+      empty.className = 'form-hint';
+      empty.textContent = 'No sources recorded yet. Run a scrape to populate this list.';
+      sourceContainer.appendChild(empty);
+      return;
+    }
+    sources.forEach((source, idx) => {
+      const id = `source_${idx}`;
+      const wrapper = document.createElement('label');
+      wrapper.className = 'multiselect__option';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.value = source;
+      checkbox.id = id;
+      checkbox.addEventListener('change', () => {
+        if (checkbox.checked) {
+          state.sources.add(source);
+        } else {
+          state.sources.delete(source);
+        }
+        scheduleFetch();
+      });
+      const span = document.createElement('span');
+      span.textContent = source;
+      wrapper.append(checkbox, span);
+      sourceContainer.appendChild(wrapper);
+    });
+  }
+
+  function renderFavouriteCpvButtons() {
+    if (!cpvFavouriteContainer) return;
+    cpvFavouriteContainer.innerHTML = '';
+    if (!favouriteCpv.length) {
+      const empty = document.createElement('p');
+      empty.className = 'form-hint';
+      empty.textContent = 'Favourite CPV codes will appear here once saved in the CPV Explorer tab.';
+      cpvFavouriteContainer.appendChild(empty);
+      return;
+    }
+    favouriteCpv.forEach(entry => {
+      if (!entry || typeof entry.code !== 'string') return;
+      const code = entry.code.trim();
+      if (!/^\d{8}$/.test(code)) return;
+      const description = entry.description || '';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = `${code}`;
+      button.title = description;
+      button.className = 'outline';
+      const updateState = () => {
+        if (state.cpv.has(code)) {
+          button.classList.add('active');
+        } else {
+          button.classList.remove('active');
+        }
+      };
+      button.addEventListener('click', () => {
+        if (state.cpv.has(code)) {
+          state.cpv.delete(code);
+        } else {
+          state.cpv.set(code, description);
+        }
+        updateState();
+        renderSelectedCpv();
+        scheduleFetch(true);
+      });
+      updateState();
+      cpvFavouriteContainer.appendChild(button);
+    });
+  }
+
+  function renderSelectedCpv() {
+    if (!cpvSelectionList) return;
+    cpvSelectionList.innerHTML = '';
+    if (!state.cpv.size) {
+      const empty = document.createElement('li');
+      empty.className = 'form-hint';
+      empty.textContent = 'No CPV filters selected.';
+      cpvSelectionList.appendChild(empty);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    state.cpv.forEach((description, code) => {
+      const li = document.createElement('li');
+      const info = document.createElement('span');
+      info.innerHTML = `<strong>${code}</strong> – ${description || 'No description'}`;
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'outline';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', () => {
+        state.cpv.delete(code);
+        renderSelectedCpv();
+        renderFavouriteCpvButtons();
+        scheduleFetch(true);
+      });
+      li.append(info, removeBtn);
+      fragment.appendChild(li);
+    });
+    cpvSelectionList.appendChild(fragment);
+    renderFavouriteCpvButtons();
+  }
+
+  function collectFilterValues() {
+    state.query = searchInput ? searchInput.value.trim() : '';
+    state.scrapedFrom = scrapedFromInput && scrapedFromInput.value ? new Date(scrapedFromInput.value).toISOString() : null;
+    state.scrapedTo = scrapedToInput && scrapedToInput.value ? new Date(scrapedToInput.value).toISOString() : null;
+    state.openFrom = openFromInput ? openFromInput.value : null;
+    state.openTo = openToInput ? openToInput.value : null;
+    state.closeFrom = closeFromInput ? closeFromInput.value : null;
+    state.closeTo = closeToInput ? closeToInput.value : null;
+    state.sort = sortField ? sortField.value : 'scraped_at';
+    state.direction = sortDirection ? sortDirection.value : 'desc';
+    const mode = Array.from(cpvModeInputs).find(r => r.checked);
+    state.cpvMode = mode ? mode.value : 'or';
+  }
+
+  let fetchTimer = null;
+  function scheduleFetch(immediate = false) {
+    if (fetchTimer) {
+      clearTimeout(fetchTimer);
+    }
+    fetchTimer = setTimeout(() => {
+      fetchTimer = null;
+      state.page = 1;
+      collectFilterValues();
+      fetchTenders();
+    }, immediate ? 0 : 250);
+  }
+
+  function updateStatus(message) {
+    if (tenderStatus) {
+      tenderStatus.textContent = message;
+    }
+  }
+
+  function formatDate(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  function formatDateTime(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString();
+  }
+
+  function renderTable(results) {
+    tableBody.innerHTML = '';
+    if (!results.length) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 8;
+      cell.textContent = 'No tenders matched the selected filters.';
+      row.appendChild(cell);
+      tableBody.appendChild(row);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    results.forEach(item => {
+      const row = document.createElement('tr');
+
+      const titleCell = document.createElement('td');
+      const titleLink = document.createElement('a');
+      titleLink.href = item.link || '#';
+      titleLink.target = '_blank';
+      titleLink.rel = 'noopener';
+      titleLink.textContent = item.title || 'Untitled tender';
+      titleCell.appendChild(titleLink);
+      if (item.description) {
+        const desc = document.createElement('div');
+        desc.className = 'table-subtext';
+        desc.textContent = item.description;
+        titleCell.appendChild(desc);
+      }
+
+      const sourceCell = document.createElement('td');
+      sourceCell.textContent = item.source || '';
+
+      const scrapedCell = document.createElement('td');
+      scrapedCell.textContent = formatDateTime(item.scrapedAt);
+
+      const openCell = document.createElement('td');
+      openCell.textContent = formatDate(item.openDate);
+
+      const closeCell = document.createElement('td');
+      closeCell.textContent = formatDate(item.closingDate);
+
+      const valueCell = document.createElement('td');
+      valueCell.textContent = item.value || '';
+
+      const cpvCell = document.createElement('td');
+      cpvCell.textContent = (item.cpvCodes || []).join(', ');
+
+      const tagsCell = document.createElement('td');
+      tagsCell.textContent = (item.tags || []).join(', ');
+
+      row.append(titleCell, sourceCell, scrapedCell, openCell, closeCell, valueCell, cpvCell, tagsCell);
+      fragment.appendChild(row);
+    });
+    tableBody.appendChild(fragment);
+  }
+
+  function updatePaginationControls() {
+    const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+    pageInfo.textContent = `Page ${state.page} of ${totalPages}`;
+    prevBtn.disabled = state.page <= 1;
+    nextBtn.disabled = state.page >= totalPages;
+  }
+
+  async function fetchTenders() {
+    updateStatus('Loading tenders…');
+    const params = new URLSearchParams();
+    params.set('page', String(state.page));
+    params.set('pageSize', String(state.pageSize));
+    if (state.query) params.set('q', state.query);
+    if (state.sources.size) {
+      state.sources.forEach(src => params.append('sources', src));
+    }
+    if (state.scrapedFrom) params.set('scrapedFrom', state.scrapedFrom);
+    if (state.scrapedTo) params.set('scrapedTo', state.scrapedTo);
+    if (state.openFrom) params.set('openFrom', state.openFrom);
+    if (state.openTo) params.set('openTo', state.openTo);
+    if (state.closeFrom) params.set('closeFrom', state.closeFrom);
+    if (state.closeTo) params.set('closeTo', state.closeTo);
+    if (state.cpv.size) {
+      state.cpv.forEach((_, code) => params.append('cpv', code));
+      params.set('cpvMode', state.cpvMode);
+    }
+    params.set('sort', state.sort);
+    params.set('direction', state.direction);
+
+    try {
+      const response = await fetch(`/api/tenders?${params.toString()}`, {
+        headers: { Accept: 'application/json' }
+      });
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const payload = await response.json();
+      state.total = payload.total || 0;
+      const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+      if (state.page > totalPages) {
+        state.page = totalPages;
+        updatePaginationControls();
+        fetchTenders();
+        return;
+      }
+      renderTable(payload.results || []);
+      updatePaginationControls();
+      if (payload.results && payload.results.length) {
+        updateStatus(`Showing ${payload.results.length} tenders (of ${payload.total || 0}).`);
+      } else {
+        updateStatus('No tenders matched the selected filters.');
+      }
+    } catch (err) {
+      console.error('Failed to load tenders', err);
+      updateStatus('Unable to load tenders. Please review the filters or retry shortly.');
+    }
+  }
+
+  function resetFilters() {
+    if (searchInput) searchInput.value = '';
+    [scrapedFromInput, scrapedToInput, openFromInput, openToInput, closeFromInput, closeToInput].forEach(input => {
+      if (input) input.value = '';
+    });
+    if (sortField) sortField.value = 'scraped_at';
+    if (sortDirection) sortDirection.value = 'desc';
+    state.sources.clear();
+    if (sourceContainer) {
+      sourceContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+        cb.checked = false;
+      });
+    }
+    state.cpv.clear();
+    if (cpvModeInputs.length) {
+      cpvModeInputs.forEach(input => {
+        input.checked = input.value === 'or';
+      });
+    }
+    renderSelectedCpv();
+    scheduleFetch(true);
+  }
+
+  if (applyBtn) {
+    applyBtn.addEventListener('click', () => {
+      collectFilterValues();
+      state.page = 1;
+      fetchTenders();
+    });
+  }
+
+  if (resetBtn) {
+    resetBtn.addEventListener('click', resetFilters);
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', () => scheduleFetch());
+  }
+
+  [
+    scrapedFromInput,
+    scrapedToInput,
+    openFromInput,
+    openToInput,
+    closeFromInput,
+    closeToInput
+  ].forEach(input => {
+    if (input) {
+      input.addEventListener('change', () => scheduleFetch(true));
+    }
+  });
+
+  if (sortField) {
+    sortField.addEventListener('change', () => scheduleFetch(true));
+  }
+
+  if (sortDirection) {
+    sortDirection.addEventListener('change', () => scheduleFetch(true));
+  }
+
+  prevBtn.addEventListener('click', () => {
+    if (state.page > 1) {
+      state.page -= 1;
+      collectFilterValues();
+      fetchTenders();
+    }
+  });
+
+  nextBtn.addEventListener('click', () => {
+    const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+    if (state.page < totalPages) {
+      state.page += 1;
+      collectFilterValues();
+      fetchTenders();
+    }
+  });
+
+  cpvModeInputs.forEach(input => {
+    input.addEventListener('change', () => {
+      if (input.checked) {
+        state.cpvMode = input.value;
+        scheduleFetch(true);
+      }
+    });
+  });
+
+  let suggestionTimer = null;
+  let suggestionRequestId = 0;
+  if (cpvSearchInput) {
+    cpvSearchInput.addEventListener('input', () => {
+      const query = cpvSearchInput.value.trim();
+      if (suggestionTimer) clearTimeout(suggestionTimer);
+      if (!query) {
+        cpvSuggestions.innerHTML = '';
+        return;
+      }
+      suggestionTimer = setTimeout(() => {
+        loadCpvSuggestions(query);
+      }, 250);
+    });
+  }
+
+  async function loadCpvSuggestions(query) {
+    const requestId = ++suggestionRequestId;
+    cpvSuggestions.textContent = 'Searching CPV codes…';
+    try {
+      const params = new URLSearchParams({ search: query, limit: '10' });
+      const response = await fetch(`/api/cpv-codes?${params.toString()}`, {
+        headers: { Accept: 'application/json' }
+      });
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const payload = await response.json();
+      if (requestId !== suggestionRequestId) {
+        return;
+      }
+      cpvSuggestions.innerHTML = '';
+      if (!payload.results || !payload.results.length) {
+        cpvSuggestions.textContent = 'No matching CPV codes found.';
+        return;
+      }
+      payload.results.forEach(result => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        const desc = result.description ? result.description : 'No description available';
+        button.textContent = `${result.code} – ${desc}`;
+        button.className = 'cpv-suggestion';
+        button.addEventListener('click', () => {
+          state.cpv.set(result.code, result.description || '');
+          cpvSearchInput.value = '';
+          cpvSuggestions.innerHTML = '';
+          renderSelectedCpv();
+          scheduleFetch(true);
+        });
+        cpvSuggestions.appendChild(button);
+      });
+    } catch (err) {
+      console.error('Failed to load CPV suggestions', err);
+      if (requestId !== suggestionRequestId) return;
+      cpvSuggestions.textContent = 'Unable to load CPV suggestions.';
+    }
+  }
+
+  renderSourceOptions();
+  renderSelectedCpv();
+  collectFilterValues();
+  fetchTenders();
+})();

--- a/frontend/tenders.ejs
+++ b/frontend/tenders.ejs
@@ -1,0 +1,127 @@
+<!--
+  File: tenders.ejs
+  Overview: Advanced tender explorer tab with faceted filters, CPV integration
+    and search controls. Powered by tenders-hub.js which retrieves data via the
+    /api/tenders endpoint.
+  Structure:
+    - Navigation and instructional banner.
+    - Filter form covering keyword, source, date and CPV options.
+    - Results table with pagination and live status feedback.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Tender Explorer</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Tenders</h1>
+  <%- include('partials/nav', { page: 'tenders', user: user }) %>
+  <div id="instructions">
+    <strong>Analyse your tender pipeline with confidence:</strong>
+    <ul>
+      <li>Combine keyword search, source filtering and CPV logic to pinpoint relevant opportunities.</li>
+      <li>Select "Match all" in the CPV section to require every chosen code, or "Match any" for a broader sweep.</li>
+      <li>Favourite codes from the CPV Explorer tab appear here for quick one-click filtering.</li>
+      <li>Most filters apply automatically; use the reset button to start again if the view feels too narrow.</li>
+    </ul>
+  </div>
+  <% if (loadError) { %>
+    <div class="status-banner error"><%= loadError %></div>
+  <% } %>
+  <section class="panel">
+    <h2>Filter tenders</h2>
+    <form id="tenderFilters" class="tender-filters">
+      <div class="filter-grid">
+        <label for="tenderSearch">Keyword search</label>
+        <input id="tenderSearch" type="search" placeholder="Search title, description, tags or CPV">
+
+        <label for="sourceSelect">Sources</label>
+        <div id="sourceSelect" class="multiselect" aria-live="polite"></div>
+
+        <label for="scrapedFrom">Scraped from</label>
+        <input id="scrapedFrom" type="datetime-local">
+
+        <label for="scrapedTo">Scraped to</label>
+        <input id="scrapedTo" type="datetime-local">
+
+        <label for="openFrom">Open from</label>
+        <input id="openFrom" type="date">
+
+        <label for="openTo">Open to</label>
+        <input id="openTo" type="date">
+
+        <label for="closeFrom">Closing from</label>
+        <input id="closeFrom" type="date">
+
+        <label for="closeTo">Closing to</label>
+        <input id="closeTo" type="date">
+
+        <label for="sortField">Sort by</label>
+        <select id="sortField">
+          <option value="scraped_at">Scraped date</option>
+          <option value="open_date">Open date</option>
+          <option value="deadline">Closing date</option>
+          <option value="published_date">Published date</option>
+          <option value="title">Title</option>
+          <option value="source">Source</option>
+        </select>
+
+        <label for="sortDirection">Sort direction</label>
+        <select id="sortDirection">
+          <option value="desc">Newest first</option>
+          <option value="asc">Oldest first</option>
+        </select>
+      </div>
+      <div class="filter-actions">
+        <button id="applyFilters" type="button">Apply filters</button>
+        <button id="resetFilters" type="button" class="outline">Reset</button>
+      </div>
+    </form>
+  </section>
+  <section class="panel">
+    <h2>CPV filtering</h2>
+    <p class="form-hint">Select CPV codes to narrow the table. Use favourites for one-click filters or search to add more.</p>
+    <div class="cpv-mode" role="radiogroup" aria-label="CPV matching mode">
+      <label><input type="radio" name="cpvMode" value="or" checked> Match any (OR)</label>
+      <label><input type="radio" name="cpvMode" value="and"> Match all (AND)</label>
+    </div>
+    <div id="cpvFilterFavourites" class="cpv-filter-favourites"></div>
+    <label for="cpvFilterSearch">Add CPV codes</label>
+    <input id="cpvFilterSearch" type="search" placeholder="Begin typing to search CPV codes">
+    <div id="cpvFilterSuggestions" class="cpv-suggestions" aria-live="polite"></div>
+    <ul id="cpvFilterSelection" class="cpv-selected"></ul>
+  </section>
+  <section class="panel">
+    <h2>Results</h2>
+    <div id="tenderStatus" class="form-hint" aria-live="polite"></div>
+    <table id="tendersTable">
+      <thead>
+        <tr>
+          <th scope="col">Title</th>
+          <th scope="col">Source</th>
+          <th scope="col">Scraped</th>
+          <th scope="col">Open date</th>
+          <th scope="col">Closing date</th>
+          <th scope="col">Value</th>
+          <th scope="col">CPV codes</th>
+          <th scope="col">Tags</th>
+        </tr>
+      </thead>
+      <tbody id="tendersTableBody"></tbody>
+    </table>
+    <div id="tenderPagination" class="pagination">
+      <button type="button" id="tenderPrev" aria-label="Previous page">Previous</button>
+      <span id="tenderPageInfo"></span>
+      <button type="button" id="tenderNext" aria-label="Next page">Next</button>
+    </div>
+  </section>
+  <script>
+    window.__TENDER_PREFILL__ = {
+      sources: <%- JSON.stringify(sources || []) %>,
+      favourites: <%- JSON.stringify(favourites || []) %>
+    };
+  </script>
+  <script src="/tenders-hub.js"></script>
+</body>
+</html>

--- a/server/db.js
+++ b/server/db.js
@@ -5,6 +5,8 @@
  * methods for managing tenders, sources and related metadata.
  */
 const sqlite3 = require('sqlite3').verbose();
+const fs = require('fs');
+const path = require('path');
 const config = require('./config');
 const logger = require('./logger');
 
@@ -17,6 +19,14 @@ const db = new sqlite3.Database(config.dbFile, err => {
     logger.error('Failed to open database:', err);
   }
 });
+
+// Track whether the CPV lookup table has already been hydrated during the
+// current process lifetime. Loading the XML list repeatedly is unnecessary and
+// wastes I/O, so the promise is reused while a load is in progress.
+let cpvLoadPromise = null;
+
+// Shared path to the CPV XML reference file packaged with the repository.
+const cpvXmlPath = path.join(__dirname, '..', 'cpv_2008_xml', 'cpv_2008.xml');
 
 // Ensure the tenders table exists before we attempt any writes. This table will
 // hold every tender that we scrape, avoiding duplicates via the UNIQUE link
@@ -192,6 +202,75 @@ db.serialize(() => {
 });
 
 /**
+ * Ensure the CPV lookup table contains data by hydrating it from the bundled
+ * XML file on demand. The import only runs when the table is empty so the
+ * operation is effectively idempotent even across application restarts.
+ *
+ * @returns {Promise<boolean>} resolves true when data was imported, false when
+ *   the table already contained rows.
+ */
+function ensureCpvCodesLoaded() {
+  if (cpvLoadPromise) {
+    return cpvLoadPromise;
+  }
+
+  cpvLoadPromise = new Promise((resolve, reject) => {
+    db.get('SELECT COUNT(*) AS c FROM cpv_codes', (countErr, row) => {
+      if (countErr) {
+        cpvLoadPromise = null;
+        return reject(countErr);
+      }
+      if (row && row.c > 0) {
+        cpvLoadPromise = null;
+        return resolve(false);
+      }
+
+      fs.readFile(cpvXmlPath, 'utf8', (readErr, xmlData) => {
+        if (readErr) {
+          cpvLoadPromise = null;
+          return reject(readErr);
+        }
+
+        const entries = [];
+        const cpvRegex = /<CPV CODE="(\d{8})-\d">([\s\S]*?)<\/CPV>/g;
+        const textRegex = /<TEXT LANG="EN">([^<]+)<\/TEXT>/;
+        let match;
+        while ((match = cpvRegex.exec(xmlData)) !== null) {
+          const [, code, block] = match;
+          const textMatch = textRegex.exec(block);
+          const description = textMatch ? textMatch[1].trim() : '';
+          if (!code) continue;
+          entries.push({ code, description });
+        }
+
+        db.serialize(() => {
+          const stmt = db.prepare(
+            'INSERT OR REPLACE INTO cpv_codes (code, description) VALUES (?, ?)'
+          );
+          entries.forEach(entry => {
+            stmt.run(entry.code, entry.description, err => {
+              if (err) {
+                logger.error('Failed to store CPV code %s: %s', entry.code, err.message);
+              }
+            });
+          });
+          stmt.finalize(finalizeErr => {
+            cpvLoadPromise = null;
+            if (finalizeErr) {
+              return reject(finalizeErr);
+            }
+            logger.info('Hydrated CPV lookup table with %d entries', entries.length);
+            resolve(true);
+          });
+        });
+      });
+    });
+  });
+
+  return cpvLoadPromise;
+}
+
+/**
  * Convert a tender date string into a normalised Date instance.
  *
  * Historical data is often stored using a mix of ISO dates (2024-06-01),
@@ -250,6 +329,7 @@ function normaliseTenderDate(value) {
 }
 
 module.exports = {
+  ensureCpvCodesLoaded,
   /**
    * Insert a tender into the database if it does not already exist.
    *
@@ -383,6 +463,57 @@ module.exports = {
   },
 
   /**
+   * Search the CPV catalogue using a combination of code and description terms.
+   *
+   * @param {object} options - Search configuration.
+   * @param {string} options.search - Free text query (optional).
+   * @param {number} options.limit - Maximum number of rows to return.
+   * @param {number} options.offset - Number of rows to skip from the start.
+   * @returns {Promise<{ rows: Array<{code:string, description:string}>, total: number }>}
+   *   Resolves with the matching CPV entries and a total count for pagination.
+   */
+  searchCpvCodes: ({ search = '', limit = 50, offset = 0 }) => {
+    return new Promise((resolve, reject) => {
+      const where = [];
+      const params = [];
+
+      const trimmed = search.trim();
+      if (trimmed) {
+        const terms = trimmed.split(/\s+/).map(t => t.trim()).filter(Boolean);
+        terms.forEach(term => {
+          const clause = ['description LIKE ?'];
+          params.push(`%${term}%`);
+          if (/^\d+$/.test(term)) {
+            clause.push('code LIKE ?');
+            params.push(`${term}%`);
+          }
+          where.push(`(${clause.join(' OR ')})`);
+        });
+      }
+
+      const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+      const countSql = `SELECT COUNT(*) AS c FROM cpv_codes ${whereSql}`;
+      const dataSql = `SELECT code, description FROM cpv_codes ${whereSql} ORDER BY code LIMIT ? OFFSET ?`;
+
+      const countParams = params.slice();
+      db.get(countSql, countParams, (countErr, countRow) => {
+        if (countErr) {
+          return reject(countErr);
+        }
+        const total = countRow ? countRow.c : 0;
+        const dataParams = params.slice();
+        dataParams.push(limit, offset);
+        db.all(dataSql, dataParams, (dataErr, rows) => {
+          if (dataErr) {
+            return reject(dataErr);
+          }
+          resolve({ rows, total });
+        });
+      });
+    });
+  },
+
+  /**
    * Insert an awarded contract if it does not already exist. The parameters
    * mirror insertTender so the scraper logic can be reused for awarded data.
    */
@@ -475,6 +606,140 @@ module.exports = {
           resolve(row || null);
         }
       );
+    });
+  },
+
+  /**
+   * Retrieve the distinct list of tender sources stored in the database so the
+   * UI can offer friendly filter controls.
+   *
+   * @returns {Promise<string[]>} resolves with an alphabetically sorted list of sources.
+   */
+  getTenderSources: () => {
+    return new Promise((resolve, reject) => {
+      db.all(
+        "SELECT DISTINCT source FROM tenders WHERE source IS NOT NULL AND source != '' ORDER BY source",
+        (err, rows) => {
+          if (err) return reject(err);
+          resolve(rows.map(r => r.source));
+        }
+      );
+    });
+  },
+
+  /**
+   * Perform an advanced tender search supporting keyword queries, date ranges,
+   * source filtering and CPV logic (AND/OR). Results are paginated so the
+   * frontend can request data incrementally.
+   *
+   * @param {object} filters - Filter definition.
+   * @param {string} [filters.query] - Free text search applied to title, description, tags and CPV.
+   * @param {string[]} [filters.sources] - Specific sources to include.
+   * @param {string} [filters.scrapedFrom] - Lower bound for scraped_at (ISO string).
+   * @param {string} [filters.scrapedTo] - Upper bound for scraped_at (ISO string).
+   * @param {string} [filters.openFrom] - Lower bound for open_date.
+   * @param {string} [filters.openTo] - Upper bound for open_date.
+   * @param {string} [filters.closeFrom] - Lower bound for deadline.
+   * @param {string} [filters.closeTo] - Upper bound for deadline.
+   * @param {string[]} [filters.cpv] - CPV codes to filter by.
+   * @param {'and'|'or'} [filters.cpvMode] - Whether every CPV must match or any.
+   * @param {string} [filters.sort] - Sort column identifier.
+   * @param {'asc'|'desc'} [filters.direction] - Sort direction.
+   * @param {number} limit - Maximum rows to return.
+   * @param {number} offset - Row offset.
+   * @returns {Promise<{ rows: any[], total: number }>} resolves with matching rows and count.
+   */
+  searchTenders: (filters, limit, offset) => {
+    return new Promise((resolve, reject) => {
+      const where = [];
+      const params = [];
+
+      if (filters.query) {
+        const like = `%${filters.query}%`;
+        where.push('(title LIKE ? OR description LIKE ? OR tags LIKE ? OR cpv LIKE ? )');
+        params.push(like, like, like, like);
+      }
+
+      if (filters.sources && filters.sources.length) {
+        const validSources = filters.sources.filter(Boolean);
+        if (validSources.length) {
+          const placeholders = validSources.map(() => '?').join(',');
+          where.push(`source IN (${placeholders})`);
+          params.push(...validSources);
+        }
+      }
+
+      if (filters.scrapedFrom) {
+        where.push('scraped_at >= ?');
+        params.push(filters.scrapedFrom);
+      }
+      if (filters.scrapedTo) {
+        where.push('scraped_at <= ?');
+        params.push(filters.scrapedTo);
+      }
+      if (filters.openFrom) {
+        where.push('open_date >= ?');
+        params.push(filters.openFrom);
+      }
+      if (filters.openTo) {
+        where.push('open_date <= ?');
+        params.push(filters.openTo);
+      }
+      if (filters.closeFrom) {
+        where.push('deadline >= ?');
+        params.push(filters.closeFrom);
+      }
+      if (filters.closeTo) {
+        where.push('deadline <= ?');
+        params.push(filters.closeTo);
+      }
+
+      if (filters.cpv && filters.cpv.length) {
+        const sanitizedCodes = filters.cpv.filter(code => /^\d{8}$/.test(code));
+        if (sanitizedCodes.length) {
+          if (filters.cpvMode === 'and') {
+            sanitizedCodes.forEach(code => {
+              where.push("instr(',' || COALESCE(cpv, '') || ',', ?) > 0");
+              params.push(`,${code},`);
+            });
+          } else {
+            const clauses = sanitizedCodes.map(() => "instr(',' || COALESCE(cpv, '') || ',', ?) > 0");
+            where.push(`(${clauses.join(' OR ')})`);
+            sanitizedCodes.forEach(code => params.push(`,${code},`));
+          }
+        }
+      }
+
+      const sortColumnMap = {
+        title: 'title COLLATE NOCASE',
+        source: 'source COLLATE NOCASE',
+        scraped_at: 'scraped_at',
+        open_date: 'open_date',
+        deadline: 'deadline',
+        published_date: 'date'
+      };
+      const sortKey = sortColumnMap[filters.sort] || 'scraped_at';
+      const sortDirection = filters.direction === 'asc' ? 'ASC' : 'DESC';
+
+      const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+      const countSql = `SELECT COUNT(*) AS c FROM tenders ${whereSql}`;
+      const dataSql = `SELECT id, title, link, date AS published_date, description, source, scraped_at, tags, cpv, open_date, deadline, raw_details FROM tenders ${whereSql} ORDER BY ${sortKey} ${sortDirection} LIMIT ? OFFSET ?`;
+
+      const countParams = params.slice();
+      db.get(countSql, countParams, (countErr, countRow) => {
+        if (countErr) {
+          return reject(countErr);
+        }
+        const total = countRow ? countRow.c : 0;
+        const dataParams = params.slice();
+        dataParams.push(limit, offset);
+        db.all(dataSql, dataParams, (dataErr, rows) => {
+          if (dataErr) {
+            return reject(dataErr);
+          }
+          resolve({ rows, total });
+        });
+      });
     });
   },
 

--- a/server/index.js
+++ b/server/index.js
@@ -113,6 +113,143 @@ function openBrowser(url) {
   exec(`${command} ${url}`);
 }
 
+/**
+ * Normalise the CPV favourites stored in the session ensuring codes are valid
+ * eight digit strings and descriptions are safe to render.
+ *
+ * @param {object} session - Express session object.
+ * @returns {Array<{code: string, description: string}>} Sanitised favourites.
+ */
+function getSessionCpvFavourites(session) {
+  const raw = Array.isArray(session.cpvFavourites) ? session.cpvFavourites : [];
+  const seen = new Set();
+  const cleaned = [];
+  raw.forEach(entry => {
+    if (!entry || typeof entry.code !== 'string') {
+      return;
+    }
+    const code = entry.code.trim();
+    if (!/^\d{8}$/.test(code) || seen.has(code)) {
+      return;
+    }
+    const description =
+      entry.description && typeof entry.description === 'string'
+        ? entry.description.trim()
+        : '';
+    seen.add(code);
+    cleaned.push({ code, description });
+  });
+  session.cpvFavourites = cleaned;
+  return cleaned;
+}
+
+/**
+ * Append a CPV favourite to the current session when it does not already
+ * exist. The updated array is returned for convenience.
+ *
+ * @param {object} session - Express session object.
+ * @param {string} code - Eight digit CPV code.
+ * @param {string} description - Friendly description sourced from the XML.
+ * @returns {Array<{code: string, description: string}>} Updated favourites.
+ */
+function addSessionCpvFavourite(session, code, description) {
+  const favourites = getSessionCpvFavourites(session);
+  if (!favourites.some(f => f.code === code)) {
+    favourites.push({ code, description });
+  }
+  session.cpvFavourites = favourites;
+  return favourites;
+}
+
+/**
+ * Remove a CPV favourite from the session if present.
+ *
+ * @param {object} session - Express session object.
+ * @param {string} code - Eight digit CPV code to delete.
+ * @returns {Array<{code: string, description: string}>} Updated favourites.
+ */
+function removeSessionCpvFavourite(session, code) {
+  const favourites = getSessionCpvFavourites(session);
+  const filtered = favourites.filter(entry => entry.code !== code);
+  session.cpvFavourites = filtered;
+  return filtered;
+}
+
+/**
+ * Attempt to derive a tender's monetary value from nested raw detail payloads.
+ * Only the first plausible value encountered is returned to avoid overwhelming
+ * the UI with multiple numbers.
+ *
+ * @param {string} rawDetails - JSON string stored alongside the tender.
+ * @returns {string} Human readable value or an empty string when none found.
+ */
+function deriveTenderValue(rawDetails) {
+  if (!rawDetails) {
+    return '';
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(rawDetails);
+  } catch (err) {
+    return '';
+  }
+
+  const visited = new Set();
+  const queue = [parsed];
+  const keys = [
+    'value',
+    'contract_value',
+    'contractValue',
+    'estimated_value',
+    'estimatedValue',
+    'budget',
+    'budget_value',
+    'budgetValue'
+  ];
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (!current || typeof current !== 'object') {
+      continue;
+    }
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    for (const key of keys) {
+      if (Object.prototype.hasOwnProperty.call(current, key)) {
+        const candidate = current[key];
+        if (candidate == null) continue;
+        if (typeof candidate === 'string' && candidate.trim()) {
+          return candidate.trim();
+        }
+        if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+          return candidate.toString();
+        }
+        if (typeof candidate === 'object') {
+          const amount = candidate.amount || candidate.value || candidate.estimation;
+          const currency = candidate.currency || candidate.currencyCode || '';
+          if (amount) {
+            const amountStr = typeof amount === 'number' ? amount.toString() : String(amount).trim();
+            if (amountStr) {
+              return currency ? `${amountStr} ${currency}`.trim() : amountStr;
+            }
+          }
+        }
+      }
+    }
+
+    Object.values(current).forEach(val => {
+      if (val && typeof val === 'object') {
+        queue.push(val);
+      }
+    });
+  }
+
+  return '';
+}
+
 // Load settings such as the cron schedule and any user-added sources from the
 // database before the server begins handling requests. This ensures the in-memory
 // configuration matches what was saved previously.
@@ -392,6 +529,184 @@ app.get('/opportunities/:id/raw', async (req, res) => {
   } catch (err) {
     logger.error('Failed to load raw tender payload:', err);
     res.status(500).json({ error: 'Unable to load tender payload' });
+  }
+});
+
+// GET /cpv - Render the CPV explorer allowing users to browse and favourite codes.
+app.get('/cpv', async (req, res) => {
+  let loadError = null;
+  try {
+    await db.ensureCpvCodesLoaded();
+  } catch (err) {
+    logger.error('Unable to initialise CPV catalogue:', err);
+    loadError = 'CPV catalogue could not be initialised. Check server logs for details.';
+  }
+  const favourites = getSessionCpvFavourites(req.session);
+  res.render('cpv', {
+    page: 'cpv',
+    favourites,
+    loadError
+  });
+});
+
+// GET /api/cpv-codes - Lightweight search endpoint backed by the cpv_codes table.
+app.get('/api/cpv-codes', async (req, res) => {
+  const search = (req.query.search || '').toString();
+  const page = Math.max(1, parseInt(req.query.page || '1', 10));
+  const pageSize = Math.min(100, Math.max(1, parseInt(req.query.limit || '25', 10)));
+  const offset = (page - 1) * pageSize;
+
+  try {
+    await db.ensureCpvCodesLoaded();
+    const { rows, total } = await db.searchCpvCodes({ search, limit: pageSize, offset });
+    res.json({
+      results: rows,
+      total,
+      page,
+      pageSize
+    });
+  } catch (err) {
+    logger.error('Failed to search CPV catalogue:', err);
+    res.status(500).json({ error: 'Unable to search CPV catalogue' });
+  }
+});
+
+// GET /api/cpv-favourites - Surface the session favourites to the frontend.
+app.get('/api/cpv-favourites', (req, res) => {
+  const favourites = getSessionCpvFavourites(req.session);
+  res.json({ favourites });
+});
+
+// POST /api/cpv-favourites - Add or remove CPV favourites stored against the session.
+app.post('/api/cpv-favourites', (req, res) => {
+  const body = req.body || {};
+  const code = typeof body.code === 'string' ? body.code.trim() : '';
+  if (!/^\d{8}$/.test(code)) {
+    return res.status(400).json({ error: 'Invalid CPV code supplied' });
+  }
+  const action = (body.action || 'add').toLowerCase();
+
+  if (action === 'remove') {
+    const favourites = removeSessionCpvFavourite(req.session, code);
+    logger.info('Removed CPV favourite %s for session %s', code, req.sessionID);
+    return res.json({ favourites });
+  }
+
+  const description =
+    body.description && typeof body.description === 'string'
+      ? body.description.trim()
+      : '';
+  if (!description) {
+    return res.status(400).json({ error: 'Description is required when favouriting a CPV code' });
+  }
+
+  const favourites = addSessionCpvFavourite(req.session, code, description);
+  if (favourites.length > 100) {
+    favourites.pop();
+    return res
+      .status(400)
+      .json({ error: 'Maximum of 100 favourites reached for this session', favourites });
+  }
+  logger.info('Added CPV favourite %s for session %s', code, req.sessionID);
+  res.json({ favourites });
+});
+
+// GET /tenders - Advanced tender browser featuring filtering and CPV discovery tools.
+app.get('/tenders', async (req, res) => {
+  let loadError = null;
+  try {
+    await db.ensureCpvCodesLoaded();
+  } catch (err) {
+    logger.error('Unable to ensure CPV catalogue for tender explorer:', err);
+    loadError = 'CPV catalogue was not fully initialised. CPV search may be limited.';
+  }
+
+  let sources = [];
+  try {
+    sources = await db.getTenderSources();
+  } catch (err) {
+    logger.error('Failed to load tender sources for explorer:', err);
+    loadError = loadError || 'Tender sources could not be loaded from the database.';
+  }
+
+  const favourites = getSessionCpvFavourites(req.session);
+  res.render('tenders', {
+    page: 'tenders',
+    sources,
+    favourites,
+    loadError
+  });
+});
+
+// GET /api/tenders - Provide filtered tender data for the explorer interface.
+app.get('/api/tenders', async (req, res) => {
+  const page = Math.max(1, parseInt(req.query.page || '1', 10));
+  const pageSize = Math.min(100, Math.max(1, parseInt(req.query.pageSize || req.query.limit || '25', 10)));
+  const offset = (page - 1) * pageSize;
+
+  const toArray = value => {
+    if (!value) return [];
+    if (Array.isArray(value)) {
+      return value.map(v => v && v.toString().trim()).filter(Boolean);
+    }
+    return value
+      .toString()
+      .split(',')
+      .map(v => v.trim())
+      .filter(Boolean);
+  };
+
+  const filters = {
+    query: (req.query.q || '').toString().trim(),
+    sources: toArray(req.query.sources),
+    scrapedFrom: (req.query.scrapedFrom || '').toString().trim() || null,
+    scrapedTo: (req.query.scrapedTo || '').toString().trim() || null,
+    openFrom: (req.query.openFrom || '').toString().trim() || null,
+    openTo: (req.query.openTo || '').toString().trim() || null,
+    closeFrom: (req.query.closeFrom || '').toString().trim() || null,
+    closeTo: (req.query.closeTo || '').toString().trim() || null,
+    cpv: toArray(req.query.cpv).filter(code => /^\d{8}$/.test(code)),
+    cpvMode: (req.query.cpvMode || 'or').toString().toLowerCase() === 'and' ? 'and' : 'or',
+    sort: (req.query.sort || '').toString(),
+    direction: (req.query.direction || '').toString().toLowerCase() === 'asc' ? 'asc' : 'desc'
+  };
+
+  try {
+    const { rows, total } = await db.searchTenders(filters, pageSize, offset);
+    const results = rows.map(row => {
+      const cpvCodes = row.cpv ? row.cpv.split(',').map(code => code.trim()).filter(Boolean) : [];
+      const tags = row.tags ? row.tags.split(',').map(tag => tag.trim()).filter(Boolean) : [];
+      return {
+        id: row.id,
+        title: row.title,
+        link: row.link,
+        source: row.source,
+        scrapedAt: row.scraped_at,
+        publishedDate: row.published_date,
+        openDate: row.open_date,
+        closingDate: row.deadline,
+        tags,
+        cpvCodes,
+        description: row.description,
+        value: deriveTenderValue(row.raw_details)
+      };
+    });
+    logger.info(
+      'Tender explorer query returned %d rows from %d total (page %d, size %d)',
+      results.length,
+      total,
+      page,
+      pageSize
+    );
+    res.json({
+      page,
+      pageSize,
+      total,
+      results
+    });
+  } catch (err) {
+    logger.error('Tender explorer query failed:', err);
+    res.status(500).json({ error: 'Unable to load tenders for the requested filters' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add a CPV Explorer page with interactive search and session-based favourites backed by the bundled CPV XML data
- introduce a Tenders explorer with keyword, source, date and CPV filters plus supporting API endpoints
- refresh navigation and styling to expose the new tabs and provide polished panels for the explorer interfaces

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd3a0babb08328b6ccc25048d4e4cf