### PR TITLE
Persist CPV favourites per account

### DIFF
--- a/frontend/cpv-browser.js
+++ b/frontend/cpv-browser.js
@@ -2,11 +2,11 @@
  * File: cpv-browser.js
  * Overview: Client-side controller for the CPV explorer tab. Handles search
  *   requests against the CPV catalogue, renders paginated results and manages
- *   the user's session-based favourites list.
+ *   the user's account-backed favourites list.
  * Structure:
  *   - Initialises UI references and local state from window.__CPV_PREFILL__.
  *   - Provides debounced search logic with pagination.
- *   - Synchronises favourite selections with the Express session API.
+ *   - Synchronises favourite selections with the authenticated favourites API.
  */
 (function () {
   const prefill = window.__CPV_PREFILL__ || {};
@@ -18,6 +18,11 @@
   const pageInfo = document.getElementById('cpvPageInfo');
   const prevBtn = document.getElementById('cpvPrevPage');
   const nextBtn = document.getElementById('cpvNextPage');
+
+  const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+  const csrfToken =
+    (window.__CSRF_TOKEN__ && window.__CSRF_TOKEN__.toString()) ||
+    (csrfMeta ? csrfMeta.getAttribute('content') : '');
 
   const state = {
     page: 1,
@@ -102,8 +107,14 @@
   async function loadFavourites() {
     try {
       const response = await fetch('/api/cpv-favourites', {
-        headers: { Accept: 'application/json' }
+        headers: {
+          Accept: 'application/json'
+        }
       });
+      if (response.status === 401) {
+        updateStatus('Please sign back in to view your saved CPV favourites.');
+        return;
+      }
       if (!response.ok) {
         throw new Error(`Server responded with ${response.status}`);
       }
@@ -169,6 +180,10 @@
   }
 
   async function modifyFavourite(code, description, shouldAdd) {
+    if (!csrfToken) {
+      updateStatus('Security token missing. Please refresh the page and try again.');
+      return;
+    }
     try {
       const payload = {
         code,
@@ -181,10 +196,15 @@
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Accept: 'application/json'
+          Accept: 'application/json',
+          'CSRF-Token': csrfToken
         },
         body: JSON.stringify(payload)
       });
+      if (response.status === 401) {
+        updateStatus('Your session has expired. Sign in again to manage favourites.');
+        return;
+      }
       const json = await response.json().catch(() => ({}));
       if (!response.ok) {
         throw new Error(json.error || `Server responded with ${response.status}`);

--- a/frontend/cpv.ejs
+++ b/frontend/cpv.ejs
@@ -2,20 +2,21 @@
   File: cpv.ejs
   Overview: Dedicated CPV explorer allowing users to browse the 2008 CPV
     catalogue bundled with the repository. The page provides an interactive
-    search experience plus per-session favourites for quick reference.
+    search experience plus account-backed favourites for quick reference.
   Structure:
     - Navigation header and headline instructions.
     - Favourites summary showcasing saved CPV codes.
     - Search form with results table powered by cpv-browser.js.
   Behaviour:
     - Fetches CPV data from /api/cpv-codes and favourites from /api/cpv-favourites.
-    - Allows codes to be added/removed from the session favourites list.
+    - Allows codes to be added/removed from the account favourites list.
 -->
 <!DOCTYPE html>
 <html>
 <head>
   <title>CPV Explorer</title>
   <link rel="stylesheet" href="/style.css">
+  <meta name="csrf-token" content="<%= csrfToken %>">
 </head>
 <body>
   <h1>CPV Explorer</h1>
@@ -25,7 +26,7 @@
     <ul>
       <li>Search the official CPV hierarchy using full or partial keywords.</li>
       <li>Click the star button beside any code to add it to your favourites list for later.</li>
-      <li>Favourite codes appear both here and on the Tenders tab for rapid filtering.</li>
+      <li>Favourite codes are linked to your account and appear across all devices, including the Tenders tab for rapid filtering.</li>
     </ul>
   </div>
   <% if (loadError) { %>
@@ -33,7 +34,7 @@
   <% } %>
   <section class="panel">
     <h2>Your favourite CPV codes</h2>
-    <p class="panel-text">Favourite codes are stored in your browser session so you can re-use them while investigating opportunities.</p>
+    <p class="panel-text">Favourite codes are securely stored against your Bid Finder account so they follow you across browsers and devices. Remove items any time using the buttons below.</p>
     <ul id="cpvFavouritesList" class="cpv-favourites"></ul>
     <p id="cpvFavouritesEmpty" class="form-hint">No favourites yet. Use the search below to bookmark the codes you care about.</p>
   </section>
@@ -65,6 +66,7 @@
     window.__CPV_PREFILL__ = {
       favourites: <%- JSON.stringify(favourites || []) %>
     };
+    window.__CSRF_TOKEN__ = '<%= csrfToken %>';
   </script>
   <script src="/cpv-browser.js"></script>
 </body>

--- a/server/db.js
+++ b/server/db.js
@@ -119,6 +119,16 @@ db.serialize(() => {
     password TEXT
   )`);
 
+  // Store per-user CPV favourites so shortlisted codes persist across devices.
+  db.run(`CREATE TABLE IF NOT EXISTS cpv_favourites (
+    user_id INTEGER NOT NULL,
+    code TEXT NOT NULL,
+    description TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, code),
+    FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+  )`);
+
   // Persist custom scraping sources so they survive process restarts. Each
   // source is keyed by a short unique string which is also used in the
   // `config.sources` object. Having the parser column allows different HTML
@@ -1305,6 +1315,73 @@ module.exports = {
   },
 
   /**
+   * Retrieve all CPV favourites that belong to the supplied user.
+   *
+   * @param {number} userId - Account identifier taken from the session.
+   * @returns {Promise<Array<{code:string,description:string}>>} favourites list.
+   */
+  getUserCpvFavourites: userId => {
+    return new Promise((resolve, reject) => {
+      db.all(
+        `SELECT code, COALESCE(description, '') AS description
+         FROM cpv_favourites
+         WHERE user_id = ?
+         ORDER BY code`,
+        [userId],
+        (err, rows) => {
+          if (err) return reject(err);
+          resolve(rows || []);
+        }
+      );
+    });
+  },
+
+  /**
+   * Insert or update a CPV favourite for the specified user.
+   *
+   * @param {number} userId - Identifier of the account storing the favourite.
+   * @param {string} code - Sanitised CPV code (eight digits).
+   * @param {string} description - Friendly description associated with the code.
+   * @returns {Promise<void>} resolves when the favourite is persisted.
+   */
+  upsertUserCpvFavourite: (userId, code, description) => {
+    return new Promise((resolve, reject) => {
+      db.run(
+        `INSERT INTO cpv_favourites (user_id, code, description)
+         VALUES (?, ?, ?)
+         ON CONFLICT(user_id, code) DO UPDATE SET
+           description = excluded.description,
+           created_at = CURRENT_TIMESTAMP`,
+        [userId, code, description],
+        err => {
+          if (err) return reject(err);
+          resolve();
+        }
+      );
+    });
+  },
+
+  /**
+   * Remove a stored CPV favourite for a user when it is no longer required.
+   *
+   * @param {number} userId - Account identifier.
+   * @param {string} code - CPV code to delete.
+   * @returns {Promise<number>} number of rows removed.
+   */
+  deleteUserCpvFavourite: (userId, code) => {
+    return new Promise((resolve, reject) => {
+      db.run(
+        'DELETE FROM cpv_favourites WHERE user_id = ? AND code = ?',
+        [userId, code],
+        function (err) {
+          if (err) return reject(err);
+          resolve(this.changes || 0);
+        }
+      );
+    });
+  },
+
+  /**
    * Update a user's stored password hash. The caller is responsible for hashing
    * the password before invoking this helper.
    *
@@ -1351,6 +1428,7 @@ module.exports = {
         db.run('DROP TABLE IF EXISTS tenders');
         db.run('DROP TABLE IF EXISTS metadata');
         db.run('DROP TABLE IF EXISTS users');
+        db.run('DROP TABLE IF EXISTS cpv_favourites');
         db.run('DROP TABLE IF EXISTS sources');
         db.run('DROP TABLE IF EXISTS source_stats');
         db.run('DROP TABLE IF EXISTS award_sources');
@@ -1376,6 +1454,14 @@ module.exports = {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT UNIQUE,
             password TEXT
+          )`);
+        db.run(`CREATE TABLE cpv_favourites (
+            user_id INTEGER NOT NULL,
+            code TEXT NOT NULL,
+            description TEXT,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (user_id, code),
+            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
           )`);
         db.run(`CREATE TABLE sources (
             key TEXT PRIMARY KEY,

--- a/server/index.js
+++ b/server/index.js
@@ -114,65 +114,53 @@ function openBrowser(url) {
 }
 
 /**
- * Normalise the CPV favourites stored in the session ensuring codes are valid
- * eight digit strings and descriptions are safe to render.
+ * Trim and clamp CPV descriptions provided by the frontend. This avoids storing
+ * unexpectedly long strings while keeping user visible data informative.
  *
- * @param {object} session - Express session object.
- * @returns {Array<{code: string, description: string}>} Sanitised favourites.
+ * @param {string} description - Raw description from the request body.
+ * @returns {string} Sanitised description safe to persist.
  */
-function getSessionCpvFavourites(session) {
-  const raw = Array.isArray(session.cpvFavourites) ? session.cpvFavourites : [];
-  const seen = new Set();
-  const cleaned = [];
-  raw.forEach(entry => {
-    if (!entry || typeof entry.code !== 'string') {
-      return;
-    }
-    const code = entry.code.trim();
-    if (!/^\d{8}$/.test(code) || seen.has(code)) {
-      return;
-    }
-    const description =
-      entry.description && typeof entry.description === 'string'
-        ? entry.description.trim()
-        : '';
-    seen.add(code);
-    cleaned.push({ code, description });
-  });
-  session.cpvFavourites = cleaned;
-  return cleaned;
-}
-
-/**
- * Append a CPV favourite to the current session when it does not already
- * exist. The updated array is returned for convenience.
- *
- * @param {object} session - Express session object.
- * @param {string} code - Eight digit CPV code.
- * @param {string} description - Friendly description sourced from the XML.
- * @returns {Array<{code: string, description: string}>} Updated favourites.
- */
-function addSessionCpvFavourite(session, code, description) {
-  const favourites = getSessionCpvFavourites(session);
-  if (!favourites.some(f => f.code === code)) {
-    favourites.push({ code, description });
+function sanitiseCpvDescription(description) {
+  if (typeof description !== 'string') {
+    return '';
   }
-  session.cpvFavourites = favourites;
-  return favourites;
+  return description.trim().slice(0, 255);
 }
 
 /**
- * Remove a CPV favourite from the session if present.
+ * Retrieve CPV favourites associated with the authenticated account. Any
+ * malformed entries are filtered to ensure downstream consumers only receive
+ * valid data.
  *
- * @param {object} session - Express session object.
- * @param {string} code - Eight digit CPV code to delete.
- * @returns {Array<{code: string, description: string}>} Updated favourites.
+ * @param {object} session - Express session which holds the logged in user.
+ * @returns {Promise<Array<{code:string, description:string}>>} favourites list.
  */
-function removeSessionCpvFavourite(session, code) {
-  const favourites = getSessionCpvFavourites(session);
-  const filtered = favourites.filter(entry => entry.code !== code);
-  session.cpvFavourites = filtered;
-  return filtered;
+async function getUserCpvFavourites(session) {
+  if (!session || !session.user || !Number.isInteger(session.user.id)) {
+    return [];
+  }
+  try {
+    const rows = await db.getUserCpvFavourites(session.user.id);
+    const seen = new Set();
+    const cleaned = [];
+    for (const entry of rows) {
+      if (!entry || typeof entry.code !== 'string') {
+        continue;
+      }
+      const code = entry.code.trim();
+      if (!/^\d{8}$/.test(code) || seen.has(code)) {
+        continue;
+      }
+      const description = sanitiseCpvDescription(entry.description || '');
+      seen.add(code);
+      cleaned.push({ code, description });
+    }
+    return cleaned;
+  } catch (err) {
+    const username = session.user && session.user.username;
+    logger.error('Failed to load CPV favourites for %s: %s', username, err.message);
+    throw err;
+  }
 }
 
 /**
@@ -533,7 +521,7 @@ app.get('/opportunities/:id/raw', async (req, res) => {
 });
 
 // GET /cpv - Render the CPV explorer allowing users to browse and favourite codes.
-app.get('/cpv', async (req, res) => {
+app.get('/cpv', requireAuth, async (req, res) => {
   let loadError = null;
   try {
     await db.ensureCpvCodesLoaded();
@@ -541,7 +529,13 @@ app.get('/cpv', async (req, res) => {
     logger.error('Unable to initialise CPV catalogue:', err);
     loadError = 'CPV catalogue could not be initialised. Check server logs for details.';
   }
-  const favourites = getSessionCpvFavourites(req.session);
+  let favourites = [];
+  try {
+    favourites = await getUserCpvFavourites(req.session);
+  } catch (err) {
+    loadError =
+      loadError || 'Your saved CPV favourites could not be loaded. Please retry shortly.';
+  }
   res.render('cpv', {
     page: 'cpv',
     favourites,
@@ -571,14 +565,19 @@ app.get('/api/cpv-codes', async (req, res) => {
   }
 });
 
-// GET /api/cpv-favourites - Surface the session favourites to the frontend.
-app.get('/api/cpv-favourites', (req, res) => {
-  const favourites = getSessionCpvFavourites(req.session);
-  res.json({ favourites });
+// GET /api/cpv-favourites - Surface saved favourites for the logged in user.
+app.get('/api/cpv-favourites', requireAuth, async (req, res) => {
+  try {
+    const favourites = await getUserCpvFavourites(req.session);
+    res.json({ favourites });
+  } catch (err) {
+    logger.error('Unable to fetch CPV favourites for %s: %s', req.session.user.username, err.message);
+    res.status(500).json({ error: 'Unable to load CPV favourites' });
+  }
 });
 
-// POST /api/cpv-favourites - Add or remove CPV favourites stored against the session.
-app.post('/api/cpv-favourites', (req, res) => {
+// POST /api/cpv-favourites - Add or remove CPV favourites saved against the user account.
+app.post('/api/cpv-favourites', requireAuth, async (req, res) => {
   const body = req.body || {};
   const code = typeof body.code === 'string' ? body.code.trim() : '';
   if (!/^\d{8}$/.test(code)) {
@@ -587,28 +586,39 @@ app.post('/api/cpv-favourites', (req, res) => {
   const action = (body.action || 'add').toLowerCase();
 
   if (action === 'remove') {
-    const favourites = removeSessionCpvFavourite(req.session, code);
-    logger.info('Removed CPV favourite %s for session %s', code, req.sessionID);
-    return res.json({ favourites });
+    try {
+      await db.deleteUserCpvFavourite(req.session.user.id, code);
+      const favourites = await getUserCpvFavourites(req.session);
+      logger.info('Removed CPV favourite %s for user %s', code, req.session.user.username);
+      return res.json({ favourites });
+    } catch (err) {
+      logger.error('Failed to remove CPV favourite %s for %s: %s', code, req.session.user.username, err.message);
+      return res.status(500).json({ error: 'Unable to update favourites' });
+    }
   }
 
-  const description =
-    body.description && typeof body.description === 'string'
-      ? body.description.trim()
-      : '';
+  const description = sanitiseCpvDescription(body.description || '');
   if (!description) {
     return res.status(400).json({ error: 'Description is required when favouriting a CPV code' });
   }
 
-  const favourites = addSessionCpvFavourite(req.session, code, description);
-  if (favourites.length > 100) {
-    favourites.pop();
-    return res
-      .status(400)
-      .json({ error: 'Maximum of 100 favourites reached for this session', favourites });
+  try {
+    const existing = await getUserCpvFavourites(req.session);
+    const alreadyTracked = existing.some(entry => entry.code === code);
+    if (!alreadyTracked && existing.length >= 200) {
+      return res.status(400).json({
+        error: 'Maximum of 200 favourites reached for this account',
+        favourites: existing
+      });
+    }
+    await db.upsertUserCpvFavourite(req.session.user.id, code, description);
+    const favourites = await getUserCpvFavourites(req.session);
+    logger.info('Added CPV favourite %s for user %s', code, req.session.user.username);
+    res.json({ favourites });
+  } catch (err) {
+    logger.error('Failed to store CPV favourite %s for %s: %s', code, req.session.user.username, err.message);
+    res.status(500).json({ error: 'Unable to update favourites' });
   }
-  logger.info('Added CPV favourite %s for session %s', code, req.sessionID);
-  res.json({ favourites });
 });
 
 // GET /tenders - Advanced tender browser featuring filtering and CPV discovery tools.
@@ -629,7 +639,12 @@ app.get('/tenders', async (req, res) => {
     loadError = loadError || 'Tender sources could not be loaded from the database.';
   }
 
-  const favourites = getSessionCpvFavourites(req.session);
+  let favourites = [];
+  try {
+    favourites = await getUserCpvFavourites(req.session);
+  } catch (err) {
+    loadError = loadError || 'Your CPV favourites were unavailable. Filtering shortcuts may be limited.';
+  }
   res.render('tenders', {
     page: 'tenders',
     sources,
@@ -834,8 +849,15 @@ app.post('/register', async (req, res) => {
   // Hash the password so only the digest is stored
   const hash = await bcrypt.hash(password, 10);
   await db.createUser(username, hash);
+  const createdUser = await db.getUserByUsername(username);
+  if (!createdUser) {
+    logger.error('User registration succeeded but lookup failed for %s', username);
+    return res
+      .status(500)
+      .render('register', { error: 'Account created but login failed. Please try signing in.', page: 'login' });
+  }
   // Log the new user in immediately and send them to the scraper page
-  req.session.user = { username };
+  req.session.user = { id: createdUser.id, username: createdUser.username };
   res.redirect('/scraper');
 });
 


### PR DESCRIPTION
## Summary
- store CPV favourites in a new per-user database table and expose helpers for managing the records
- require authentication for CPV favourites APIs while adding CSRF token handling to the frontend client
- refresh the CPV explorer UI to reference account-backed favourites and embed the CSRF token for scripted requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd3f5cc1b4832888b7451f6ed39c72