### PR TITLE
Add parser selection dropdowns and parser reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 
 # Local databases
 *.db
+*.sqlite
 
 # Logs and runtime data
 logs

--- a/frontend/admin-tools.js
+++ b/frontend/admin-tools.js
@@ -43,6 +43,10 @@ document.addEventListener('DOMContentLoaded', () => {
     awardSources: Object.assign({}, initial.awardSources || {}),
     sourceStats: Object.assign({}, initial.sourceStats || {}),
     sourceStatus: Object.assign({}, initial.sourceStatus || {}),
+    parserCatalogue: Array.isArray(initial.parserCatalogue)
+      ? initial.parserCatalogue.map(option => ({ ...option }))
+      : [],
+    defaultParser: initial.defaultParser || 'contractsFinder',
     editing: {
       tender: null,
       award: null
@@ -96,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
             label: tenderSourceForm.querySelector('input[name="label"]'),
             url: tenderSourceForm.querySelector('input[name="url"]'),
             base: tenderSourceForm.querySelector('input[name="base"]'),
-            parser: tenderSourceForm.querySelector('input[name="parser"]')
+            parser: tenderSourceForm.querySelector('[name="parser"]')
           },
           submit: tenderSourceForm.querySelector('button[type="submit"]'),
           cancel: tenderSourceForm.querySelector('[data-action="cancel-edit"]')
@@ -110,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
             label: awardSourceForm.querySelector('input[name="label"]'),
             url: awardSourceForm.querySelector('input[name="url"]'),
             base: awardSourceForm.querySelector('input[name="base"]'),
-            parser: awardSourceForm.querySelector('input[name="parser"]')
+            parser: awardSourceForm.querySelector('[name="parser"]')
           },
           submit: awardSourceForm.querySelector('button[type="submit"]'),
           cancel: awardSourceForm.querySelector('[data-action="cancel-edit"]')
@@ -119,15 +123,24 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   const tableBodies = { tender: tenderSourceBody, award: awardSourceBody };
   const sourceBanners = { tender: tenderSourceBanner, award: awardSourceBanner };
+  const defaultParserKey = state.defaultParser || 'contractsFinder';
+  const parserLookup = Array.isArray(state.parserCatalogue)
+    ? state.parserCatalogue.reduce((acc, option) => {
+        if (option && option.key) {
+          acc[option.key] = option.label || option.key;
+        }
+        return acc;
+      }, {})
+    : {};
   const defaultParser = {
     tender:
       formControls.tender && formControls.tender.inputs.parser
-        ? formControls.tender.inputs.parser.value || 'contractsFinder'
-        : 'contractsFinder',
+        ? formControls.tender.inputs.parser.value || defaultParserKey
+        : defaultParserKey,
     award:
       formControls.award && formControls.award.inputs.parser
-        ? formControls.award.inputs.parser.value || 'contractsFinder'
-        : 'contractsFinder'
+        ? formControls.award.inputs.parser.value || defaultParserKey
+        : defaultParserKey
   };
   const apiRoutes = { tender: '/sources', award: '/award-sources' };
   const testRoutes = { tender: '/test-source', award: '/test-award-source' };
@@ -327,7 +340,14 @@ document.addEventListener('DOMContentLoaded', () => {
         labelCell.appendChild(labelTitle);
         const metaBits = [];
         if (src && src.base) metaBits.push(src.base);
-        if (src && src.parser) metaBits.push(`Parser: ${src.parser}`);
+        if (src && src.parser) {
+          const label = parserLookup[src.parser];
+          const parserMeta =
+            label && label !== src.parser
+              ? `Parser: ${src.parser} (${label})`
+              : `Parser: ${src.parser}`;
+          metaBits.push(parserMeta);
+        }
         if (metaBits.length) {
           const meta = document.createElement('div');
           meta.className = 'source-meta';

--- a/frontend/admin.ejs
+++ b/frontend/admin.ejs
@@ -128,11 +128,22 @@
         <li>Provide the site <strong>Base URL</strong> (for example
           <code>https://www.contractsfinder.service.gov.uk</code>). Links in the
           feed are resolved against this value.</li>
-        <li>Leave the <strong>Parser</strong> as <code>contractsFinder</code> unless
-          the feed requires a bespoke parser. Documentation for available parsers
-          lives on the Help page.</li>
+        <li>Pick the <strong>Parser</strong> from the dropdown. Each option notes
+          where it should be used and the default matches most Contracts Finder
+          feeds.</li>
       </ol>
     </div>
+    <details class="parser-reference" open>
+      <summary>Parser reference</summary>
+      <ul class="parser-reference-list">
+        <% parserCatalogue.forEach(parser => { %>
+          <li>
+            <strong><%= parser.label %></strong>
+            (<code><%= parser.key %></code>) &ndash; <%= parser.description %>
+          </li>
+        <% }) %>
+      </ul>
+    </details>
     <div class="source-columns">
       <article class="source-column" aria-labelledby="tender-sources-heading">
         <h3 id="tender-sources-heading">Tender sources</h3>
@@ -180,8 +191,14 @@
               </div>
               <div class="form-field">
                 <label for="tenderSourceParser">Parser</label>
-                <input id="tenderSourceParser" name="parser" type="text" value="contractsFinder" autocomplete="off">
-                <span class="form-hint">Advanced: override only if instructed.</span>
+                <select id="tenderSourceParser" name="parser" autocomplete="off">
+                  <% parserCatalogue.forEach(parser => { %>
+                    <option value="<%= parser.key %>" <%= parser.key === defaultParser ? 'selected' : '' %> title="<%= parser.description %>">
+                      <%= parser.label %>
+                    </option>
+                  <% }) %>
+                </select>
+                <span class="form-hint">Select the parser that matches your feed. Hover the options for quick guidance.</span>
               </div>
             </div>
             <div class="form-actions">
@@ -238,8 +255,14 @@
               </div>
               <div class="form-field">
                 <label for="awardSourceParser">Parser</label>
-                <input id="awardSourceParser" name="parser" type="text" value="contractsFinder" autocomplete="off">
-                <span class="form-hint">Advanced: override only if instructed.</span>
+                <select id="awardSourceParser" name="parser" autocomplete="off">
+                  <% parserCatalogue.forEach(parser => { %>
+                    <option value="<%= parser.key %>" <%= parser.key === defaultParser ? 'selected' : '' %> title="<%= parser.description %>">
+                      <%= parser.label %>
+                    </option>
+                  <% }) %>
+                </select>
+                <span class="form-hint">Choose the parser suited to the award feed. The default handles Contracts Finder listings.</span>
               </div>
             </div>
             <div class="form-actions">
@@ -348,7 +371,9 @@
     sources,
     awardSources,
     sourceStats,
-    sourceStatus
+    sourceStatus,
+    parserCatalogue,
+    defaultParser
   }).replace(/</g, '\\u003c') %></script>
   <script type="module" src="/admin-tools.js"></script>
 </body>

--- a/frontend/help.ejs
+++ b/frontend/help.ejs
@@ -1,3 +1,14 @@
+<!--
+  @file help.ejs
+  @description Help and onboarding guidance for administrators configuring
+    tender and award sources. The page summarises required fields, documents the
+    available parsers and lists example award feeds so setup can be completed
+    without referencing external documentation.
+  @structure
+    1. Global instructions for adding new sources.
+    2. Parser reference table describing each built-in parser and when to use it.
+    3. Example award sources for quick copy/paste testing.
+-->
 <!DOCTYPE html>
 <html>
 <head>
@@ -15,10 +26,27 @@
       <li><strong>Label</strong> &ndash; human readable name displayed in lists</li>
       <li><strong>Search URL</strong> &ndash; RSS feed or results page containing opportunities</li>
       <li><strong>Base URL</strong> &ndash; website root prepended to relative links</li>
-      <li><strong>Parser</strong> &ndash; name of the HTML parser (e.g. <code>rss</code>)</li>
+      <li><strong>Parser</strong> &ndash; choose the parser from the dropdown. The default (<code><%= defaultParser %></code>) matches most Contracts Finder feeds.</li>
     </ul>
     <p>Award sources follow the same structure but point at feeds of awarded contracts.</p>
-    <p>Available parser names are <code>contractsFinder</code> (default), <code>rss</code>, <code>eusupply</code>, <code>sell2wales</code> and <code>ukri</code>.</p>
+  </div>
+  <div id="parser-reference">
+    <h2>Parser Reference</h2>
+    <p>Pick the parser that best matches the target website. Hover the parser dropdown on the Scraper or Admin pages to view these descriptions inline.</p>
+    <table>
+      <thead>
+        <tr><th>Parser</th><th>Key</th><th>When to use</th></tr>
+      </thead>
+      <tbody>
+        <% parserCatalogue.forEach(parser => { %>
+          <tr>
+            <td><%= parser.label %></td>
+            <td><code><%= parser.key %></code></td>
+            <td><%= parser.description %></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
   </div>
   <h2>Example Award Sources</h2>
   <table>

--- a/frontend/scraper.ejs
+++ b/frontend/scraper.ejs
@@ -18,6 +18,17 @@
   <div id="instructions">
     Manage tender and award sources here. Hover over each input for guidance or
     visit the <a href="/help">help page</a> for full instructions.
+    <details class="parser-reference" open>
+      <summary>Parser reference</summary>
+      <ul class="parser-reference-list">
+        <% parserCatalogue.forEach(parser => { %>
+          <li>
+            <strong><%= parser.label %></strong>
+            (<code><%= parser.key %></code>) &ndash; <%= parser.description %>
+          </li>
+        <% }) %>
+      </ul>
+    </details>
   </div>
   <!-- Collapsible section listing administrative database actions -->
   <details id="dbTools" open>
@@ -117,7 +128,13 @@
             <input class="editLabel" value="<%= sources[key].label %>">
             <input class="editUrl" value="<%= sources[key].url %>">
             <input class="editBase" value="<%= sources[key].base %>">
-            <input class="editParser" value="<%= sources[key].parser %>">
+            <select class="editParser" title="Parser">
+              <% parserCatalogue.forEach(parser => { %>
+                <option value="<%= parser.key %>" <%= sources[key].parser === parser.key ? 'selected' : '' %> title="<%= parser.description %>">
+                  <%= parser.label %>
+                </option>
+              <% }) %>
+            </select>
             <button class="saveBtn">Save</button>
             <button class="cancelBtn">Cancel</button>
           </div>
@@ -131,8 +148,14 @@
     <input id="newLabel" placeholder="Label" title="Display name" required>
     <input id="newUrl" placeholder="Search URL" title="Feed or search page" required>
     <input id="newBase" placeholder="Base URL" title="Website root" required>
-    <!-- Optional parser name; defaults to Contracts Finder if left unchanged -->
-    <input id="newParser" placeholder="Parser" title="Parser name" value="contractsFinder">
+    <!-- Parser selection determines which HTML/RSS parser will normalise the feed -->
+    <select id="newParser" title="Parser">
+      <% parserCatalogue.forEach(parser => { %>
+        <option value="<%= parser.key %>" <%= parser.key === defaultParser ? 'selected' : '' %> title="<%= parser.description %>">
+          <%= parser.label %>
+        </option>
+      <% }) %>
+    </select>
     <button id="addBtn" type="submit">Add Source</button>
   </form>
 
@@ -176,7 +199,13 @@
             <input class="editLabel" value="<%= awardSources[key].label %>">
             <input class="editUrl" value="<%= awardSources[key].url %>">
             <input class="editBase" value="<%= awardSources[key].base %>">
-            <input class="editParser" value="<%= awardSources[key].parser %>">
+            <select class="editParser" title="Parser">
+              <% parserCatalogue.forEach(parser => { %>
+                <option value="<%= parser.key %>" <%= awardSources[key].parser === parser.key ? 'selected' : '' %> title="<%= parser.description %>">
+                  <%= parser.label %>
+                </option>
+              <% }) %>
+            </select>
             <button class="saveBtn">Save</button>
             <button class="cancelBtn">Cancel</button>
           </div>
@@ -191,7 +220,13 @@
     <input id="newAwardUrl" placeholder="Search URL" title="Award feed" required>
     <input id="newAwardBase" placeholder="Base URL" title="Website root" required>
     <!-- Optional parser field for award feed scraping -->
-    <input id="newAwardParser" placeholder="Parser" title="Parser name" value="contractsFinder">
+    <select id="newAwardParser" title="Parser">
+      <% parserCatalogue.forEach(parser => { %>
+        <option value="<%= parser.key %>" <%= parser.key === defaultParser ? 'selected' : '' %> title="<%= parser.description %>">
+          <%= parser.label %>
+        </option>
+      <% }) %>
+    </select>
     <button id="addAwardBtn" type="submit">Add Award Source</button>
   </form>
 
@@ -203,6 +238,7 @@
 const csrfToken = '<%= csrfToken %>';
 const sourceData = <%= JSON.stringify(sources).replace(/</g, '\u003c') %>;
 const awardSourceData = <%= JSON.stringify(awardSources).replace(/</g, '\u003c') %>;
+const defaultParser = '<%= defaultParser %>';
 let editingKey = null;
 let editingAwardKey = null;
 const statusBanner = document.getElementById('dbToolStatus');
@@ -359,7 +395,7 @@ document.getElementById('addSourceForm').addEventListener('submit', async e => {
   const label = document.getElementById('newLabel').value.trim();
   const url = document.getElementById('newUrl').value.trim();
   const base = document.getElementById('newBase').value.trim();
-  // Parser field allows custom HTML parsing rules
+  // Parser dropdown selects the HTML/RSS parsing logic applied to the feed
   const parser = document.getElementById('newParser').value.trim();
   let method = 'POST';
   let endpoint = '/sources';
@@ -400,8 +436,8 @@ document.querySelectorAll('#sourceTable .sourceRow').forEach(row => {
     e.stopPropagation();
     editingKey = null;
     document.getElementById('newKey').disabled = false;
-    // Reset parser field to the default value
-    document.getElementById('newParser').value = 'contractsFinder';
+    // Reset parser field to the default value configured server-side
+    document.getElementById('newParser').value = defaultParser;
     document.getElementById('addBtn').textContent = 'Add Source';
   });
   detail.querySelector('.deleteBtn').addEventListener('click', async ev => {
@@ -420,7 +456,7 @@ document.getElementById('addAwardSourceForm').addEventListener('submit', async e
   const label = document.getElementById('newAwardLabel').value.trim();
   const url = document.getElementById('newAwardUrl').value.trim();
   const base = document.getElementById('newAwardBase').value.trim();
-  // Award parser allows custom extraction from award feeds
+  // Award parser dropdown mirrors the tender parser selection
   const parser = document.getElementById('newAwardParser').value.trim();
   let method = 'POST';
   let endpoint = '/award-sources';
@@ -476,7 +512,7 @@ document.querySelectorAll('#awardSourceTable .awardSourceRow').forEach(row => {
     editingAwardKey = null;
     document.getElementById('newAwardKey').disabled = false;
     // Reset award parser to the default parser name
-    document.getElementById('newAwardParser').value = 'contractsFinder';
+    document.getElementById('newAwardParser').value = defaultParser;
     document.getElementById('addAwardBtn').textContent = 'Add Award Source';
   });
   detail.querySelector('.deleteBtn').addEventListener('click', async ev => {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -208,6 +208,31 @@ button:hover {
   box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
 }
 
+details.parser-reference {
+  background: #fff;
+  border: 1px solid #d0d7de;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin: 1rem 0;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.04);
+}
+
+details.parser-reference summary {
+  font-weight: 600;
+  cursor: pointer;
+  color: #0f172a;
+}
+
+.parser-reference-list {
+  margin: 0.75rem 0 0;
+  padding-left: 1.25rem;
+  line-height: 1.5;
+}
+
+.parser-reference-list li {
+  margin-bottom: 0.4rem;
+}
+
 .instruction-card h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;

--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -18,6 +18,65 @@
 const cheerio = require('cheerio');
 
 /**
+ * Identifier used when no parser is specified. Exposed so the UI can present
+ * a consistent default option and server code can reference a single source of
+ * truth instead of repeating string literals.
+ */
+const DEFAULT_PARSER_KEY = 'contractsFinder';
+
+/**
+ * Catalogue describing the built-in parsers. The admin and scraper UIs use the
+ * metadata to present human-friendly dropdowns and the help page renders the
+ * descriptions so operators can choose the correct parser for each source.
+ */
+const PARSER_CATALOGUE = Object.freeze(
+  [
+    {
+      key: DEFAULT_PARSER_KEY,
+      label: 'Contracts Finder (HTML)',
+      description:
+        'Purpose-built for the Contracts Finder HTML listings when an RSS feed is unavailable. '
+        + 'Use this when scraping the Contracts Finder search results pages directly.'
+    },
+    {
+      key: 'rss',
+      label: 'RSS / Atom feed',
+      description:
+        'Generic RSS and Atom parser that reads standard feed elements. Choose this whenever '
+        + 'a source exposes a valid RSS or Atom feed of opportunities.'
+    },
+    {
+      key: 'generic',
+      label: 'Generic (CSS selectors)',
+      description:
+        'Uses custom CSS selectors configured for the source to extract fields. '
+        + 'Select only when advanced selectors have been defined for the feed.'
+    },
+    {
+      key: 'eusupply',
+      label: 'EU Supply',
+      description:
+        'Handles the unique markup produced by EU Supply portals such as uk.eu-supply.com. '
+        + 'Select this for opportunities sourced from EU Supply instances.'
+    },
+    {
+      key: 'sell2wales',
+      label: 'Sell2Wales',
+      description:
+        'Tailored to the Sell2Wales opportunity listings. Apply this parser when scraping '
+        + 'sell2wales.gov.wales feeds or HTML listings.'
+    },
+    {
+      key: 'ukri',
+      label: 'UK Research and Innovation',
+      description:
+        'Optimised for the UK Research and Innovation tender portal. Use it for ukri.org '
+        + 'procurement listings.'
+    }
+  ].map(option => Object.freeze(option))
+);
+
+/**
  * Normalise a snippet of markup by stripping tags and collapsing whitespace.
  * @param {string} str Raw HTML or text.
  * @returns {string} Cleaned string.
@@ -433,17 +492,18 @@ function parseRss(xml) {
  * @param {string|object} source Either a parser key or full source definition.
  * @returns {Array<object>} Parsed tender rows.
  */
-exports.parseTenders = function parseTenders(html, source = 'contractsFinder') {
+exports.parseTenders = function parseTenders(html, source = DEFAULT_PARSER_KEY) {
   const sourceConfig =
     typeof source === 'string' || !source
-      ? { parser: source || 'contractsFinder' }
+      ? { parser: source || DEFAULT_PARSER_KEY }
       : source;
 
   if (sourceConfig && sourceConfig.selectors) {
     return parseGeneric(html, sourceConfig.selectors);
   }
 
-  const parserKey = sourceConfig && sourceConfig.parser ? sourceConfig.parser : 'contractsFinder';
+  const parserKey =
+    sourceConfig && sourceConfig.parser ? sourceConfig.parser : DEFAULT_PARSER_KEY;
 
   switch (parserKey) {
     case 'eusupply':
@@ -454,8 +514,11 @@ exports.parseTenders = function parseTenders(html, source = 'contractsFinder') {
       return parseUkri(html);
     case 'rss':
       return parseRss(html);
-    case 'contractsFinder':
+    case DEFAULT_PARSER_KEY:
     default:
       return parseContractsFinder(html);
   }
 };
+
+exports.PARSER_CATALOGUE = PARSER_CATALOGUE;
+exports.DEFAULT_PARSER_KEY = DEFAULT_PARSER_KEY;

--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,11 @@ const config = require('./config');
 const logger = require('./logger');
 const bcrypt = require('bcryptjs');
 const fetch = require('node-fetch');
-const { parseTenders } = require('./htmlParser');
+const {
+  parseTenders,
+  PARSER_CATALOGUE,
+  DEFAULT_PARSER_KEY
+} = require('./htmlParser');
 // Built-in modules used for checking port availability and launching the browser
 const net = require('net');
 const { exec } = require('child_process');
@@ -27,6 +31,36 @@ const { exec } = require('child_process');
 const sourceStore = require('./sourceStore');
 // Lightweight CSRF protection middleware providing req.csrfToken().
 const csrf = require('./csrf');
+
+/**
+ * Provide templates with a cloned parser catalogue so server constants cannot
+ * be mutated accidentally when rendering EJS pages.
+ *
+ * @returns {Array<{key: string, label: string, description: string}>}
+ */
+function buildParserCatalogue() {
+  return PARSER_CATALOGUE.map(option => ({ ...option }));
+}
+
+// Precompute a set of valid parser keys so incoming requests can be validated.
+const parserKeySet = new Set(PARSER_CATALOGUE.map(option => option.key));
+
+/**
+ * Ensure a supplied parser key is recognised, falling back to the default when
+ * no match exists. Trimming prevents entries with stray whitespace.
+ *
+ * @param {string} parserKey - Key provided by the client/UI
+ * @returns {string} Valid parser key safe to persist
+ */
+function normaliseParserKey(parserKey) {
+  if (typeof parserKey === 'string') {
+    const trimmed = parserKey.trim();
+    if (parserKeySet.has(trimmed)) {
+      return trimmed;
+    }
+  }
+  return DEFAULT_PARSER_KEY;
+}
 
 // Build an allow list of domains permitted when defining new sources. This
 // prevents the application from being tricked into fetching arbitrary URLs
@@ -737,6 +771,8 @@ app.get('/scraper', requireAuth, async (req, res) => {
     sourceStats: stats,
     sourceStatus,
     cron: config.cronSchedule,
+    parserCatalogue: buildParserCatalogue(),
+    defaultParser: DEFAULT_PARSER_KEY,
     page: 'scraper'
   });
 });
@@ -768,6 +804,8 @@ app.get('/help', (req, res) => {
   res.render('help', {
     sources: config.sources,
     awardSources: config.awardSources,
+    parserCatalogue: buildParserCatalogue(),
+    defaultParser: DEFAULT_PARSER_KEY,
     page: 'help'
   });
 });
@@ -882,7 +920,8 @@ app.get('/manage-users', requireAuth, (req, res) => {
 // Persist new sources in the database so they remain available after a restart.
 // The parser field defaults to "contractsFinder" since it matches our test HTML.
 app.post('/sources', requireAuth, async (req, res) => {
-  const { key, label, url, base, parser = 'contractsFinder' } = req.body || {};
+  const { key, label, url, base, parser = DEFAULT_PARSER_KEY } = req.body || {};
+  const parserKey = normaliseParserKey(parser);
 
   // Basic validation of the supplied data
   if (!key || !label || !url || !base) {
@@ -906,8 +945,8 @@ app.post('/sources', requireAuth, async (req, res) => {
   try {
     // Store the new source definition then add it to the in-memory object used
     // by the rest of the application.
-    await db.insertSource(key, label, url, base, parser);
-    const record = { label, url, base, parser };
+    await db.insertSource(key, label, url, base, parserKey);
+    const record = { label, url, base, parser: parserKey };
     config.sources[key] = record;
     sourceStatus[key] = 'unknown';
     // Persist the updated configuration so custom sources survive restarts.
@@ -925,7 +964,8 @@ app.post('/sources', requireAuth, async (req, res) => {
 // new one.
 app.put('/sources/:key', requireAuth, async (req, res) => {
   const key = req.params.key;
-  const { label, url, base, parser = 'contractsFinder' } = req.body || {};
+  const { label, url, base, parser = DEFAULT_PARSER_KEY } = req.body || {};
+  const parserKey = normaliseParserKey(parser);
 
   if (!config.sources[key]) {
     return res.status(404).json({ error: 'Source not found' });
@@ -943,8 +983,8 @@ app.put('/sources/:key', requireAuth, async (req, res) => {
   }
 
   try {
-    await db.updateSource(key, label, url, base, parser);
-    const record = { label, url, base, parser };
+    await db.updateSource(key, label, url, base, parserKey);
+    const record = { label, url, base, parser: parserKey };
     config.sources[key] = record;
     sourceStatus[key] = 'unknown';
     // Persist changes so they are reloaded on the next start.
@@ -982,7 +1022,8 @@ app.delete('/sources/:key', requireAuth, async (req, res) => {
 
 // POST /award-sources - Add a new award scraping source.
 app.post('/award-sources', requireAuth, async (req, res) => {
-  const { key, label, url, base, parser = 'contractsFinder' } = req.body || {};
+  const { key, label, url, base, parser = DEFAULT_PARSER_KEY } = req.body || {};
+  const parserKey = normaliseParserKey(parser);
 
   if (!key || !label || !url || !base) {
     return res.status(400).json({ error: 'Missing required fields' });
@@ -1000,8 +1041,8 @@ app.post('/award-sources', requireAuth, async (req, res) => {
   }
 
   try {
-    await db.insertAwardSource(key, label, url, base, parser);
-    const record = { label, url, base, parser };
+    await db.insertAwardSource(key, label, url, base, parserKey);
+    const record = { label, url, base, parser: parserKey };
     config.awardSources[key] = record;
     sourceStatus[key] = 'unknown';
     // Ensure award source changes survive server restarts.
@@ -1017,7 +1058,8 @@ app.post('/award-sources', requireAuth, async (req, res) => {
 // PUT /award-sources/:key - Update an existing award source.
 app.put('/award-sources/:key', requireAuth, async (req, res) => {
   const key = req.params.key;
-  const { label, url, base, parser = 'contractsFinder' } = req.body || {};
+  const { label, url, base, parser = DEFAULT_PARSER_KEY } = req.body || {};
+  const parserKey = normaliseParserKey(parser);
 
   if (!config.awardSources[key]) {
     return res.status(404).json({ error: 'Source not found' });
@@ -1035,8 +1077,8 @@ app.put('/award-sources/:key', requireAuth, async (req, res) => {
   }
 
   try {
-    await db.updateAwardSource(key, label, url, base, parser);
-    const record = { label, url, base, parser };
+    await db.updateAwardSource(key, label, url, base, parserKey);
+    const record = { label, url, base, parser: parserKey };
     config.awardSources[key] = record;
     sourceStatus[key] = 'unknown';
     // Persist the updated award sources list.
@@ -1302,7 +1344,9 @@ app.get('/admin', requireAuth, requireAdmin, async (req, res) => {
       sources: config.sources,
       awardSources: config.awardSources,
       sourceStats,
-      sourceStatus
+      sourceStatus,
+      parserCatalogue: buildParserCatalogue(),
+      defaultParser: DEFAULT_PARSER_KEY
     });
   } catch (err) {
     logger.error('Failed to render admin console:', err);


### PR DESCRIPTION
## Summary
- expose a parser catalogue/default in the backend and validate parser keys before persisting sources
- replace parser text inputs with dropdowns in the admin and scraper UIs and surface inline parser guidance
- expand the help page with parser descriptions, style the new guidance blocks, and ignore sqlite session files

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd428b16c48328a7e7f4d7fa42424b