### PR TITLE
Display CPV favourite descriptions in tender filter

### DIFF
--- a/frontend/tenders-hub.js
+++ b/frontend/tenders-hub.js
@@ -104,8 +104,11 @@
       const description = entry.description || '';
       const button = document.createElement('button');
       button.type = 'button';
-      button.textContent = `${code}`;
-      button.title = description;
+      // Present the favourite using both the code and its label so users can
+      // recognise it without relying on the tooltip alone.
+      const label = description ? `${code} – ${description}` : code;
+      button.textContent = label;
+      button.title = description || code;
       button.className = 'outline';
       const updateState = () => {
         if (state.cpv.has(code)) {


### PR DESCRIPTION
## Summary
- render CPV favourite buttons with both the code and description for easier identification
- keep tooltips useful by falling back to the code when no description is provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd43a3f600832897412756bf976156