### PR TITLE
Add pagination coverage for scraper detail extraction

### DIFF
--- a/test/scrape.test.js
+++ b/test/scrape.test.js
@@ -1,3 +1,16 @@
+/**
+ * File: test/scrape.test.js
+ * Mini README: Integration-style tests for the main tender scraper.
+ *
+ * Structure:
+ *   - Shared setup creates in-memory database and HTTP/pagination stubs.
+ *   - "parses tenders" test verifies baseline single-page behaviour.
+ *   - "follows pagination" test asserts multi-page detail extraction and storage.
+ *
+ * The suite focuses on ensuring scraper.js walks every results page, fetches
+ * the individual tender detail pages, and persists consistent structured data
+ * including absolute URLs and parsed metadata.
+ */
 const { expect } = require('chai');
 const fs = require('fs');
 const path = require('path');
@@ -26,12 +39,29 @@ fetchTextStub.onCall(2).resolves('<div>CPV 87654321</div>');
 const limitFn = sinon.stub().callsFake(async task => task());
 const createLimiterStub = sinon.stub().resolves(limitFn);
 
+// Pagination helpers are stubbed so tests can explicitly control when the
+// scraper should request additional pages.
+const resolvePaginationConfigStub = sinon
+  .stub()
+  .callsFake(source => ({
+    maxPages: source?.pagination?.maxPages ?? 25,
+    navSelectors: source?.pagination?.navSelectors || [],
+    nextLinkSelectors: source?.pagination?.nextLinkSelectors || [],
+    pageNumberPattern: '\\d+',
+    detectLoops: source?.pagination?.detectLoops ?? true
+  }));
+const findNextPageUrlStub = sinon.stub().returns(null);
+
 // Proxyquire allows us to inject the stubbed HTTP helper, limiter and the real
 // db instance when requiring the scraper module.
 const scrape = proxyquire('../server/scrape', {
   './httpClient': { fetchText: fetchTextStub },
   './concurrency': { createLimiter: createLimiterStub },
-  './db': db
+  './db': db,
+  './pagination': {
+    resolvePaginationConfig: resolvePaginationConfigStub,
+    findNextPageUrl: findNextPageUrlStub
+  }
 });
 
 beforeEach(async () => {
@@ -42,6 +72,18 @@ beforeEach(async () => {
   fetchTextStub.onCall(0).resolves(html);
   fetchTextStub.onCall(1).resolves('<div>CPV 12345678</div>');
   fetchTextStub.onCall(2).resolves('<div>CPV 87654321</div>');
+  resolvePaginationConfigStub.resetHistory();
+  resolvePaginationConfigStub.resetBehavior();
+  resolvePaginationConfigStub.callsFake(source => ({
+    maxPages: source?.pagination?.maxPages ?? 25,
+    navSelectors: source?.pagination?.navSelectors || [],
+    nextLinkSelectors: source?.pagination?.nextLinkSelectors || [],
+    pageNumberPattern: '\\d+',
+    detectLoops: source?.pagination?.detectLoops ?? true
+  }));
+  findNextPageUrlStub.resetHistory();
+  findNextPageUrlStub.resetBehavior();
+  findNextPageUrlStub.onCall(0).returns(null);
 });
 
 describe('scrape.run', () => {
@@ -62,5 +104,111 @@ describe('scrape.run', () => {
     const supp = await db.getOrganisationsByType('supplier');
     expect(cust).to.have.length(2);
     expect(supp).to.have.length(2);
+  });
+
+  it('follows pagination and stores detail page metadata for every tender', async () => {
+    const pageOneHtml = `
+      <div class="search-result">
+        <h2>Page 1 Contract</h2>
+        <span class="org">Org1</span>
+        <span class="supplier">Sup1</span>
+        <a href="/c1" data-ocid="ocds-p1"></a>
+        <span class="date">2024-04-01</span>
+        <p>Summary one</p>
+      </div>`;
+    const pageTwoHtml = `
+      <div class="search-result">
+        <h2>Page 2 Contract</h2>
+        <span class="org">Org2</span>
+        <span class="supplier">Sup2</span>
+        <a href="/c2" data-ocid="ocds-p2"></a>
+        <span class="date">2024-05-01</span>
+        <p>Summary two</p>
+      </div>`;
+    const detailOneHtml = `
+      Published date
+      1 May 2024
+      Closing date
+      15 May 2024
+      Name of buying organisation
+      Buyer One Ltd
+      Address
+      1 Street
+      Country
+      England
+      Description
+      Detail description 1
+      Eligibility
+      Eligible 1
+      11111111`;
+    const detailTwoHtml = `
+      Published date
+      2 May 2024
+      Response deadline
+      20 May 2024
+      Buyer
+      Buyer Two Plc
+      Address
+      2 Road
+      Country
+      Scotland
+      Description
+      Detail description 2
+      Eligibility
+      Eligible 2
+      22222222`;
+
+    fetchTextStub.resetBehavior();
+    fetchTextStub.resetHistory();
+    fetchTextStub.onCall(0).resolves(pageOneHtml);
+    fetchTextStub.onCall(1).resolves(pageTwoHtml);
+    fetchTextStub.onCall(2).resolves(detailOneHtml);
+    fetchTextStub.onCall(3).resolves(detailTwoHtml);
+
+    findNextPageUrlStub.resetBehavior();
+    findNextPageUrlStub.resetHistory();
+    findNextPageUrlStub.onCall(0).returns('https://example.com/page2');
+    findNextPageUrlStub.onCall(1).returns(null);
+
+    const source = {
+      label: 'Test Multi Page',
+      url: 'https://example.com/page1',
+      base: 'https://example.com',
+      parser: 'contractsFinder',
+      pagination: { maxPages: 5, detectLoops: true, navSelectors: [], nextLinkSelectors: [] }
+    };
+
+    const count = await scrape.run(null, source);
+    expect(count).to.equal(2);
+    expect(fetchTextStub.callCount).to.equal(4);
+
+    const rows = await db.getTenders();
+    expect(rows).to.have.length(2);
+
+    const byTitle = Object.fromEntries(rows.map(row => [row.title, row]));
+    const tenderOne = byTitle['Page 1 Contract'];
+    const tenderTwo = byTitle['Page 2 Contract'];
+
+    expect(tenderOne.link).to.equal('https://example.com/c1');
+    expect(tenderTwo.link).to.equal('https://example.com/c2');
+
+    expect(tenderOne.cpv).to.equal('11111111');
+    expect(tenderTwo.cpv).to.equal('22222222');
+
+    expect(tenderOne.description).to.equal('Detail description 1');
+    expect(tenderTwo.description).to.equal('Detail description 2');
+
+    expect(tenderOne.open_date).to.equal('1 May 2024');
+    expect(tenderOne.deadline).to.equal('15 May 2024');
+    expect(tenderTwo.deadline).to.equal('20 May 2024');
+    expect(tenderTwo.customer).to.equal('Buyer Two Plc');
+
+    const payloadOne = JSON.parse(tenderOne.raw_details);
+    const payloadTwo = JSON.parse(tenderTwo.raw_details);
+
+    expect(payloadOne.resolvedLink).to.equal('https://example.com/c1');
+    expect(payloadTwo.resolvedLink).to.equal('https://example.com/c2');
+    expect(payloadOne.detailPageHtml).to.include('Detail description 1');
+    expect(payloadTwo.detailPageHtml).to.include('Detail description 2');
   });
 });

--- a/test/scrapeAwarded.test.js
+++ b/test/scrapeAwarded.test.js
@@ -1,0 +1,203 @@
+/**
+ * File: test/scrapeAwarded.test.js
+ * Mini README: Integration checks for the awarded-contract scraper.
+ *
+ * Structure:
+ *   - Shared setup wires an in-memory database and HTTP/pagination stubs.
+ *   - Single test exercises multi-page scraping and detail enrichment.
+ *
+ * The goal is to prove scrapeAwarded.js iterates through every results page,
+ * resolves absolute URLs, harvests award detail pages, and persists structured
+ * data (including buyer metadata) into the awards tables.
+ */
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+process.env.DB_FILE = ':memory:';
+delete require.cache[require.resolve('../server/db')];
+const db = require('../server/db');
+
+const fetchTextStub = sinon.stub();
+const limitFn = sinon.stub().callsFake(async task => task());
+const createLimiterStub = sinon.stub().resolves(limitFn);
+const resolvePaginationConfigStub = sinon
+  .stub()
+  .callsFake(source => ({
+    maxPages: source?.pagination?.maxPages ?? 25,
+    navSelectors: source?.pagination?.navSelectors || [],
+    nextLinkSelectors: source?.pagination?.nextLinkSelectors || [],
+    pageNumberPattern: '\\d+',
+    detectLoops: source?.pagination?.detectLoops ?? true
+  }));
+const findNextPageUrlStub = sinon.stub().returns(null);
+
+const scrapeAwarded = proxyquire('../server/scrapeAwarded', {
+  './httpClient': { fetchText: fetchTextStub },
+  './concurrency': { createLimiter: createLimiterStub },
+  './db': db,
+  './pagination': {
+    resolvePaginationConfig: resolvePaginationConfigStub,
+    findNextPageUrl: findNextPageUrlStub
+  }
+});
+
+beforeEach(async () => {
+  await db.ready;
+  await db.deleteAllTenders();
+  fetchTextStub.resetBehavior();
+  fetchTextStub.resetHistory();
+  resolvePaginationConfigStub.resetHistory();
+  resolvePaginationConfigStub.resetBehavior();
+  resolvePaginationConfigStub.callsFake(source => ({
+    maxPages: source?.pagination?.maxPages ?? 25,
+    navSelectors: source?.pagination?.navSelectors || [],
+    nextLinkSelectors: source?.pagination?.nextLinkSelectors || [],
+    pageNumberPattern: '\\d+',
+    detectLoops: source?.pagination?.detectLoops ?? true
+  }));
+  findNextPageUrlStub.resetHistory();
+  findNextPageUrlStub.resetBehavior();
+  findNextPageUrlStub.onCall(0).returns(null);
+});
+
+describe('scrapeAwarded.run', () => {
+  it('scrapes all pages and stores award details from detail views', async () => {
+    const pageOneHtml = `
+      <div class="search-result">
+        <h2>Award Page 1</h2>
+        <span class="org">Buyer One</span>
+        <span class="supplier">Supplier One</span>
+        <a href="/a1"></a>
+        <span class="date">2024-04-01</span>
+        <p>Award summary 1</p>
+      </div>`;
+    const pageTwoHtml = `
+      <div class="search-result">
+        <h2>Award Page 2</h2>
+        <span class="org">Buyer Two</span>
+        <span class="supplier">Supplier Two</span>
+        <a href="/a2"></a>
+        <span class="date">2024-05-01</span>
+        <p>Award summary 2</p>
+      </div>`;
+    const detailOneHtml = `
+      Award Page 1
+      Buyer One
+      Location of contract
+      London
+      Value of contract
+      £100,000
+      Procurement reference
+      REF-1
+      Closing date
+      10 May 2024
+      Closing time
+      12:00
+      Contract start date
+      1 June 2024
+      Contract end date
+      31 May 2025
+      Contract type
+      Services
+      Procedure type
+      Open
+      What is Open?
+      Competitive procedure
+      Contract is suitable for SMEs?
+      Yes
+      Contract is suitable for VCSEs?
+      No
+      How to apply
+      Email buyer
+      About the buyer
+      Address
+      1 Street
+      London
+      Email
+      buyer.one@example.com`;
+    const detailTwoHtml = `
+      Award Page 2
+      Buyer Two
+      Location of contract
+      Glasgow
+      Value of contract
+      £250,000
+      Procurement reference
+      REF-2
+      Closing date
+      20 May 2024
+      Closing time
+      17:00
+      Contract start date
+      1 July 2024
+      Contract end date
+      30 June 2025
+      Contract type
+      Works
+      Procedure type
+      Restricted
+      What is Restricted?
+      Invited suppliers only
+      Contract is suitable for SMEs?
+      No
+      Contract is suitable for VCSEs?
+      Yes
+      How to apply
+      Portal link
+      About the buyer
+      Address
+      2 Road
+      Glasgow
+      Email
+      buyer.two@example.com`;
+
+    fetchTextStub.onCall(0).resolves(pageOneHtml);
+    fetchTextStub.onCall(1).resolves(pageTwoHtml);
+    fetchTextStub.onCall(2).resolves(detailOneHtml);
+    fetchTextStub.onCall(3).resolves(detailTwoHtml);
+
+    findNextPageUrlStub.resetBehavior();
+    findNextPageUrlStub.onCall(0).returns('https://example.com/page2');
+    findNextPageUrlStub.onCall(1).returns(null);
+
+    const source = {
+      label: 'Awards Multi Page',
+      url: 'https://example.com/page1',
+      base: 'https://example.com',
+      parser: 'contractsFinder',
+      pagination: { maxPages: 5, detectLoops: true, navSelectors: [], nextLinkSelectors: [] }
+    };
+
+    const inserted = await scrapeAwarded.run(null, source);
+    expect(inserted).to.equal(2);
+    expect(fetchTextStub.callCount).to.equal(4);
+
+    const awards = await db.getAwards();
+    expect(awards).to.have.length(2);
+
+    const byTitle = Object.fromEntries(awards.map(row => [row.title, row]));
+    const awardOne = byTitle['Award Page 1'];
+    const awardTwo = byTitle['Award Page 2'];
+
+    expect(awardOne.link).to.equal('https://example.com/a1');
+    expect(awardTwo.link).to.equal('https://example.com/a2');
+
+    const awardOneDetails = await db.getAwardDetails(awardOne.id);
+    const awardTwoDetails = await db.getAwardDetails(awardTwo.id);
+
+    expect(awardOneDetails.location).to.equal('London');
+    expect(awardOneDetails.value).to.equal('£100,000');
+    expect(awardOneDetails.contract_type).to.equal('Services');
+    expect(awardOneDetails.suitable_for_sme).to.equal(1);
+    expect(awardOneDetails.suitable_for_vcse).to.equal(0);
+    expect(awardOneDetails.buyer_email).to.equal('buyer.one@example.com');
+
+    expect(awardTwoDetails.location).to.equal('Glasgow');
+    expect(awardTwoDetails.value).to.equal('£250,000');
+    expect(awardTwoDetails.contract_type).to.equal('Works');
+    expect(awardTwoDetails.suitable_for_sme).to.equal(0);
+    expect(awardTwoDetails.suitable_for_vcse).to.equal(1);
+    expect(awardTwoDetails.buyer_email).to.equal('buyer.two@example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add integration-style tender scraper test that drives pagination, detail fetching, and structured persistence checks
- introduce awarded scraper coverage ensuring multi-page iteration and detail metadata storage
- document test files and stub pagination helpers so behaviour can be controlled deterministically

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd5750bc548328b0011623e985db17