### PR TITLE
Add per-source scrape controls across dashboard and admin

### DIFF
--- a/frontend/admin-tools.js
+++ b/frontend/admin-tools.js
@@ -157,6 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   const apiRoutes = { tender: '/sources', award: '/award-sources' };
   const testRoutes = { tender: '/test-source', award: '/test-award-source' };
+  const scrapeRoutes = { tender: '/scrape-stream', award: '/scrape-awarded-stream' };
 
   /**
    * Display a status message within the supplied banner element.
@@ -465,7 +466,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function normaliseStatus(value) {
-    return value ? String(value) : 'unknown';
+    switch (value) {
+      case 'ok':
+        return 'Healthy';
+      case 'error':
+        return 'Error';
+      case 'running':
+        return 'Running…';
+      case 'unknown':
+      default:
+        return 'Unknown';
+    }
   }
 
   function formatTimestamp(value) {
@@ -559,6 +570,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const actions = document.createElement('td');
         actions.className = 'source-actions';
+        const scrapeBtn = document.createElement('button');
+        scrapeBtn.type = 'button';
+        scrapeBtn.className = 'scrape-now source-scrape';
+        scrapeBtn.textContent = 'Scrape now';
+        scrapeBtn.addEventListener('click', () => triggerSourceScrape(kind, key));
+
         const testBtn = document.createElement('button');
         testBtn.type = 'button';
         testBtn.className = 'secondary source-test';
@@ -577,7 +594,7 @@ document.addEventListener('DOMContentLoaded', () => {
         deleteBtn.textContent = 'Delete';
         deleteBtn.addEventListener('click', () => confirmDeleteSource(kind, key));
 
-        actions.append(testBtn, editBtn, deleteBtn);
+        actions.append(scrapeBtn, testBtn, editBtn, deleteBtn);
 
         row.append(keyCell, labelCell, statusCell, lastScrapedCell, lastAddedCell, totalCell, actions);
         fragment.appendChild(row);
@@ -588,6 +605,147 @@ document.addEventListener('DOMContentLoaded', () => {
   function renderSources() {
     renderSourceTable('tender');
     renderSourceTable('award');
+  }
+
+  /** Disable or enable all action buttons within a source table row. */
+  function setRowDisabled(row, disabled) {
+    if (!row) return;
+    row.querySelectorAll('button').forEach(btn => {
+      btn.disabled = disabled;
+    });
+  }
+
+  /**
+   * Fetch the latest scraping statistics from the server and re-render both
+   * tender and award tables so timestamps stay current after a manual run.
+   *
+   * @returns {Promise<void>}
+   */
+  async function refreshSourceStatsData() {
+    const res = await fetch('/admin/source-stats', {
+      headers: { Accept: 'application/json' }
+    });
+    if (res.status === 401) {
+      redirectToLogin();
+      throw new Error('Session expired');
+    }
+    if (res.status === 403) {
+      throw new Error('Administrator access required to refresh source statistics.');
+    }
+    if (!res.ok) {
+      throw new Error(`Failed to refresh source statistics (status ${res.status})`);
+    }
+    const rows = await res.json();
+    const next = {};
+    (Array.isArray(rows) ? rows : []).forEach(row => {
+      if (row && row.key) {
+        next[row.key] = row;
+      }
+    });
+    state.sourceStats = next;
+    renderSourceTable('tender');
+    renderSourceTable('award');
+  }
+
+  /**
+   * Trigger a live scrape for a single source via the SSE endpoint so
+   * administrators can debug a feed without touching others.
+   *
+   * @param {'tender'|'award'} kind - Source type.
+   * @param {string} key - Source identifier.
+   */
+  function triggerSourceScrape(kind, key) {
+    const route = scrapeRoutes[kind];
+    if (!route) return;
+    const banner = sourceBanners[kind];
+    const collection = getSourceCollection(kind);
+    const source = collection[key] || {};
+    const label = source.label || key;
+    const row = tableBodies[kind]
+      ? tableBodies[kind].querySelector(`tr[data-key="${key}"]`)
+      : null;
+    const statusCell = row ? row.querySelector('.source-status') : null;
+
+    hideStatus(banner);
+    announce(banner, `Scraping ${label}…`, 'info');
+    state.sourceStatus[key] = 'running';
+    if (statusCell) statusCell.textContent = 'Running…';
+    setRowDisabled(row, true);
+
+    const url = new URL(route, window.location.origin);
+    url.searchParams.set('source', key);
+    const es = new EventSource(url.toString());
+
+    es.onmessage = evt => {
+      let payload;
+      try {
+        payload = JSON.parse(evt.data);
+      } catch (err) {
+        console.error('Invalid payload from scrape stream', err);
+        return;
+      }
+
+      if (payload.step === 'tender' && payload.total) {
+        const total = Number(payload.total) || 0;
+        const index = Number(payload.index) || 0;
+        if (statusCell) {
+          statusCell.textContent = total
+            ? `Processing ${index}/${total}`
+            : 'Processing feed…';
+        }
+      }
+
+      if (payload.done) {
+        es.close();
+        setRowDisabled(row, false);
+
+        if (payload.error) {
+          state.sourceStatus[key] = 'error';
+          if (statusCell) statusCell.textContent = 'Error';
+          announce(
+            banner,
+            `Scrape failed for ${label}: ${payload.error}`,
+            'error'
+          );
+          return;
+        }
+
+        state.sourceStatus[key] = 'ok';
+        if (statusCell) statusCell.textContent = 'Refreshing statistics…';
+        const noun = kind === 'award' ? 'awards' : 'tenders';
+        const added = Number(payload.added) || 0;
+        const successMessage =
+          added > 0
+            ? `Scrape completed. Added ${added} new ${noun}.`
+            : `Scrape completed. No new ${noun} were stored.`;
+
+        refreshSourceStatsData()
+          .then(() => {
+            announce(banner, successMessage, 'success');
+          })
+          .catch(err => {
+            console.error('Unable to refresh source statistics', err);
+            announce(
+              banner,
+              `${successMessage} Statistics refresh failed; check connectivity.`,
+              'info'
+            );
+          });
+      }
+    };
+
+    es.onerror = err => {
+      console.error('Stream error while scraping source', err);
+      es.close();
+      setRowDisabled(row, false);
+      state.sourceStatus[key] = 'error';
+      if (statusCell) statusCell.textContent = 'Error';
+      announce(
+        banner,
+        `Connection lost while scraping ${label}. Check server logs for details.`,
+        'error'
+      );
+    };
   }
 
   function resetSourceForm(kind, focus = false) {

--- a/frontend/dashboard.ejs
+++ b/frontend/dashboard.ejs
@@ -1,3 +1,15 @@
+<!--
+  @file dashboard.ejs
+  @description Landing page summarising scraper activity for quick status
+    checks. The dashboard renders a summary of stored records, exposes manual
+    "scrape now" controls for every configured source and streams application
+    logs so operators can monitor progress without opening the terminal.
+  @structure
+    1. Page shell, navigation and global "scrape all" control.
+    2. Summary list covering total tenders, awards, customers and suppliers.
+    3. Source status list with individual scrape controls and progress output.
+    4. Client-side script handling log streaming and scrape triggers.
+-->
 <!DOCTYPE html>
 <html>
 <head>
@@ -7,59 +19,243 @@
 <body>
   <h1>Dashboard</h1>
   <%- include('partials/nav', { page: 'dashboard', user: user }) %>
-  <button id="scrapeAll">Scrape All Now</button>
-  <div id="feed"></div>
+  <div class="action-row">
+    <button id="scrapeAll">Scrape all sources now</button>
+  </div>
+  <div id="feed" class="log-feed" aria-live="polite" aria-label="Live scraper log output"></div>
   <!-- Quick overview showing how much data has been scraped so far -->
   <h2>Summary</h2>
-  <ul>
-    <li>Open tenders: <%= counts.tenders %></li>
-    <li>Awarded contracts: <%= counts.awards %></li>
-    <li>Customers: <%= counts.customers %></li>
-    <li>Suppliers: <%= counts.suppliers %></li>
+  <ul class="summary-list">
+    <li><strong>Open tenders</strong>: <%= counts.tenders %></li>
+    <li><strong>Awarded contracts</strong>: <%= counts.awards %></li>
+    <li><strong>Customers</strong>: <%= counts.customers %></li>
+    <li><strong>Suppliers</strong>: <%= counts.suppliers %></li>
   </ul>
-  <h2>Source Status</h2>
-  <ul>
-    <% Object.keys(sources).forEach(key => { %>
-      <li id="status-<%= key %>">
-        <span class="status-light <%= sourceStatus[key] === 'ok' ? 'ok' : sourceStatus[key] === 'error' ? 'error' : '' %>"></span>
-        <%= sources[key].label %>
+  <h2>Source status</h2>
+  <p class="hint">Run individual scrapes to debug a problematic feed without touching the rest of the schedule.</p>
+  <ul class="source-list" id="sourceStatusList">
+    <% Object.keys(sources).forEach(key => { const source = sources[key]; %>
+      <li id="status-<%= key %>" data-source-key="<%= key %>">
+        <div class="source-list-details">
+          <span class="status-light <%= sourceStatus[key] === 'ok' ? 'ok' : sourceStatus[key] === 'error' ? 'error' : '' %>" aria-hidden="true"></span>
+          <div class="source-list-meta">
+            <span class="source-label"><%= source.label %></span>
+            <% if (source.base) { %>
+              <span class="source-meta"><%= source.base %></span>
+            <% } %>
+          </div>
+        </div>
+        <div class="source-list-actions">
+          <button type="button" class="scrape-now" data-source="<%= key %>">Scrape now</button>
+          <span class="scrape-feedback" data-role="feedback" aria-live="polite"></span>
+        </div>
       </li>
     <% }) %>
   </ul>
 <script>
-// Display log messages from the server in real time
-const feed = document.getElementById('feed');
-const logStream = new EventSource('/logs');
-logStream.onmessage = e => {
-  const data = JSON.parse(e.data);
-  const div = document.createElement('div');
-  div.textContent = `[${data.level}] ${data.message}`;
-  feed.appendChild(div);
-  feed.scrollTop = feed.scrollHeight;
-};
+// eslint-disable-next-line no-unused-vars
+(function initialiseDashboard() {
+  // Cache source metadata and status flags rendered by the server so we can
+  // update indicators instantly before fresh data is fetched.
+  const sourceData = <%- JSON.stringify(sources).replace(/</g, '\u003c') %>;
+  const statusCache = Object.assign({}, <%- JSON.stringify(sourceStatus).replace(/</g, '\u003c') %>);
 
-// Trigger a scrape of all sources using SSE progress reporting
-function runScrape(){
-  const es = new EventSource('/scrape-all-stream');
-  es.onmessage = evt => {
-    const data = JSON.parse(evt.data);
-    if(data.done){
-      es.close();
-    } else if(data.source){
-      const li = document.getElementById('status-'+data.source);
-      if(li){
-        const light = li.querySelector('.status-light');
-        if(data.error){
-          light.classList.add('error');
-        } else {
-          light.classList.add('ok');
-        }
-      }
+  const feed = document.getElementById('feed');
+  const scrapeAllBtn = document.getElementById('scrapeAll');
+  const sourceButtons = Array.from(document.querySelectorAll('button.scrape-now'));
+
+  /**
+   * Helper returning the list item representing a source. We keep lookups
+   * centralised to avoid duplicated selectors.
+   * @param {string} key - Source identifier
+   * @returns {HTMLLIElement|null}
+   */
+  function getSourceListItem(key) {
+    return document.querySelector(`li[data-source-key="${key}"]`);
+  }
+
+  /**
+   * Update the coloured status indicator for a source to reflect the most
+   * recent result.
+   * @param {string} key - Source identifier
+   * @param {'ok'|'error'|'running'|'unknown'} state - Visual state to apply
+   */
+  function setStatusLight(key, state) {
+    const item = getSourceListItem(key);
+    if (!item) return;
+    const light = item.querySelector('.status-light');
+    if (!light) return;
+    light.classList.remove('ok', 'error', 'running');
+    if (state === 'ok') light.classList.add('ok');
+    if (state === 'error') light.classList.add('error');
+    if (state === 'running') light.classList.add('running');
+  }
+
+  /**
+   * Provide human friendly feedback beneath a source button.
+   * @param {string} key - Source identifier
+   * @param {string} message - Message to display
+   */
+  function setFeedback(key, message) {
+    const item = getSourceListItem(key);
+    if (!item) return;
+    const feedback = item.querySelector('[data-role="feedback"]');
+    if (feedback) {
+      feedback.textContent = message;
+    }
+  }
+
+  /** Enable or disable every per-source button. */
+  function toggleSourceButtons(disabled) {
+    sourceButtons.forEach(btn => {
+      btn.disabled = disabled;
+    });
+  }
+
+  // Display log messages from the server in real time to assist debugging.
+  const logStream = new EventSource('/logs');
+  logStream.onmessage = e => {
+    try {
+      const data = JSON.parse(e.data);
+      const div = document.createElement('div');
+      div.textContent = `[${data.level}] ${data.message}`;
+      feed.appendChild(div);
+      feed.scrollTop = feed.scrollHeight;
+    } catch (err) {
+      console.error('Failed to parse log stream payload', err);
     }
   };
-}
 
-document.getElementById('scrapeAll').addEventListener('click', runScrape);
+  /**
+   * Run a scrape for a specific source using the SSE endpoint for progress.
+   * @param {string} key - Source identifier
+   */
+  function runScrapeForSource(key) {
+    const meta = sourceData[key];
+    if (!meta) return;
+
+    setStatusLight(key, 'running');
+    setFeedback(key, 'Starting scrape…');
+    const button = sourceButtons.find(btn => btn.dataset.source === key);
+    if (button) button.disabled = true;
+
+    const route = new URL('/scrape-stream', window.location.origin);
+    route.searchParams.set('source', key);
+    const es = new EventSource(route.toString());
+
+    es.onmessage = evt => {
+      let payload;
+      try {
+        payload = JSON.parse(evt.data);
+      } catch (err) {
+        console.error('Invalid SSE payload for scrape stream', err);
+        return;
+      }
+
+      if (payload.step === 'tender' && payload.total) {
+        setFeedback(key, `Processing ${payload.index}/${payload.total} results…`);
+      }
+
+      if (payload.done) {
+        es.close();
+        if (button) button.disabled = false;
+        if (payload.error) {
+          statusCache[key] = 'error';
+          setStatusLight(key, 'error');
+          setFeedback(key, `Scrape failed: ${payload.error}`);
+        } else {
+          statusCache[key] = 'ok';
+          setStatusLight(key, 'ok');
+          const added = typeof payload.added === 'number' ? payload.added : 0;
+          const duration = typeof payload.duration === 'number' ? payload.duration : 0;
+          const durationMsg = duration ? ` in ${duration}s` : '';
+          setFeedback(key, added ? `Added ${added} new tenders${durationMsg}.` : `No new tenders${durationMsg}.`);
+        }
+      }
+    };
+
+    es.onerror = err => {
+      console.error('Scrape stream error', err);
+      es.close();
+      if (button) button.disabled = false;
+      statusCache[key] = 'error';
+      setStatusLight(key, 'error');
+      setFeedback(key, 'Stream interrupted. Check server logs.');
+    };
+  }
+
+  // Trigger a scrape of all sources using SSE progress reporting.
+  function runScrapeAll() {
+    setFeedback('*', '');
+    toggleSourceButtons(true);
+    if (scrapeAllBtn) scrapeAllBtn.disabled = true;
+    Object.keys(sourceData).forEach(key => {
+      setStatusLight(key, 'running');
+      setFeedback(key, 'Queued…');
+      statusCache[key] = 'running';
+    });
+
+    const es = new EventSource('/scrape-all-stream');
+    es.onmessage = evt => {
+      let payload;
+      try {
+        payload = JSON.parse(evt.data);
+      } catch (err) {
+        console.error('Invalid payload from scrape-all stream', err);
+        return;
+      }
+
+      if (payload.source) {
+        const state = payload.error ? 'error' : 'ok';
+        statusCache[payload.source] = state;
+        setStatusLight(payload.source, state === 'ok' ? 'ok' : 'error');
+        setFeedback(
+          payload.source,
+          payload.error ? `Failed: ${payload.error}` : 'Scrape completed.'
+        );
+      }
+
+      if (payload.done) {
+        if (payload.results) {
+          Object.entries(payload.results).forEach(([key, result]) => {
+            const state = result && result.error ? 'error' : 'ok';
+            statusCache[key] = state;
+            setStatusLight(key, state === 'ok' ? 'ok' : 'error');
+            if (result && result.error) {
+              setFeedback(key, `Failed: ${result.error}`);
+            } else {
+              setFeedback(key, 'Scrape completed.');
+            }
+          });
+        }
+        es.close();
+        toggleSourceButtons(false);
+        if (scrapeAllBtn) scrapeAllBtn.disabled = false;
+      }
+    };
+
+    es.onerror = err => {
+      console.error('Scrape-all stream error', err);
+      es.close();
+      toggleSourceButtons(false);
+      if (scrapeAllBtn) scrapeAllBtn.disabled = false;
+      Object.keys(sourceData).forEach(key => {
+        if (statusCache[key] !== 'ok') {
+          setStatusLight(key, 'error');
+          setFeedback(key, 'Stream interrupted before completion.');
+        }
+      });
+    };
+  }
+
+  // Wire up click handlers once the DOM has been prepared.
+  if (scrapeAllBtn) {
+    scrapeAllBtn.addEventListener('click', runScrapeAll);
+  }
+  sourceButtons.forEach(btn => {
+    btn.addEventListener('click', () => runScrapeForSource(btn.dataset.source));
+  });
+})();
 </script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -341,6 +341,87 @@ details.parser-reference summary {
   flex: 0 1 auto;
 }
 
+.source-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.source-list li {
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.source-list-details {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.source-list-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.source-list-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+button.scrape-now,
+button#scrapeAll {
+  background: #2563eb;
+  color: #fff;
+}
+
+button.scrape-now:hover,
+button#scrapeAll:hover {
+  background: #1d4ed8;
+}
+
+button.scrape-now:disabled,
+button#scrapeAll:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.scrape-feedback {
+  font-size: 0.85rem;
+  color: #475569;
+  min-height: 1.2rem;
+}
+
+.log-feed {
+  margin-top: 1rem;
+  max-height: 220px;
+  overflow-y: auto;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+}
+
+.summary-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
 .source-label {
   font-weight: 600;
   color: #0f172a;
@@ -566,6 +647,7 @@ button.danger:hover {
 .status-light { width:12px; height:12px; border-radius:50%; background:#ccc; display:inline-block; margin-right:0.5rem; }
 .status-light.ok { background:#0a0; }
 .status-light.error { background:#d00; }
+.status-light.running { background:#f59e0b; }
 
 /* Pagination controls placed below tables */
 .pagination {

--- a/server/index.js
+++ b/server/index.js
@@ -1099,8 +1099,16 @@ app.get('/scrape', requireAuth, async (req, res) => {
   const sourceKey = req.query.source || 'default';
   const source = config.sources[sourceKey] || config.sources.default;
   logger.info(`Manual scrape triggered for ${sourceKey}`);
-  const newTenders = await scrape.run(null, source, sourceKey);
-  res.json({ added: newTenders });
+  sourceStatus[sourceKey] = 'running';
+  try {
+    const newTenders = await scrape.run(null, source, sourceKey);
+    sourceStatus[sourceKey] = 'ok';
+    res.json({ added: newTenders });
+  } catch (err) {
+    sourceStatus[sourceKey] = 'error';
+    logger.error('Manual scrape failed for %s: %s', sourceKey, err.message);
+    res.status(500).json({ error: 'Scrape failed', details: err.message });
+  }
 });
 
 // Trigger the awards scraper for a specific source.
@@ -1108,8 +1116,16 @@ app.get('/scrape-awarded', requireAuth, async (req, res) => {
   const sourceKey = req.query.source || 'default';
   const source = config.awardSources[sourceKey] || config.awardSources.default;
   logger.info(`Manual awards scrape triggered for ${sourceKey}`);
-  const added = await scrapeAwarded.run(null, source, sourceKey);
-  res.json({ added });
+  sourceStatus[sourceKey] = 'running';
+  try {
+    const added = await scrapeAwarded.run(null, source, sourceKey);
+    sourceStatus[sourceKey] = 'ok';
+    res.json({ added });
+  } catch (err) {
+    sourceStatus[sourceKey] = 'error';
+    logger.error('Manual awards scrape failed for %s: %s', sourceKey, err.message);
+    res.status(500).json({ error: 'Scrape failed', details: err.message });
+  }
 });
 
 // GET /scrape-all - Run the scraper against every configured source. This
@@ -1117,14 +1133,26 @@ app.get('/scrape-awarded', requireAuth, async (req, res) => {
 // returns a summary of how many tenders were added per source.
 app.get('/scrape-all', requireAuth, async (req, res) => {
   logger.info('Manual scrape triggered for all sources');
+  Object.keys(config.sources).forEach(key => {
+    sourceStatus[key] = 'running';
+  });
   const results = await scrape.runAll();
+  Object.entries(results).forEach(([key, result]) => {
+    sourceStatus[key] = result && result.error ? 'error' : 'ok';
+  });
   res.json(results);
 });
 
 // Scrape all award sources sequentially and return per-source stats.
 app.get('/scrape-awarded-all', requireAuth, async (req, res) => {
   logger.info('Manual awards scrape triggered for all sources');
+  Object.keys(config.awardSources).forEach(key => {
+    sourceStatus[key] = 'running';
+  });
   const results = await scrapeAwarded.runAll();
+  Object.entries(results).forEach(([key, result]) => {
+    sourceStatus[key] = result && result.error ? 'error' : 'ok';
+  });
   res.json(results);
 });
 
@@ -1138,7 +1166,13 @@ app.get('/scrape-all-stream', requireAuth, async (req, res) => {
   res.flushHeaders();
 
   const send = data => res.write(`data: ${JSON.stringify(data)}\n\n`);
+  Object.keys(config.sources).forEach(key => {
+    sourceStatus[key] = 'running';
+  });
   const results = await scrape.runAll(p => send(p));
+  Object.entries(results).forEach(([key, result]) => {
+    sourceStatus[key] = result && result.error ? 'error' : 'ok';
+  });
   send({ done: true, results });
   res.end();
 });
@@ -1168,15 +1202,26 @@ app.get('/scrape-stream', requireAuth, async (req, res) => {
 
   // Run the scraper and stream progress for each tender found. The selected
   // source is forwarded to the scraper so different sites can be targeted.
-  const count = await scrape.run(progress => send(progress), source, sourceKey);
-
-  // Emit a final message indicating completion and close the connection.
-  send({
-    done: true,
-    added: count,
-    duration: Math.round((Date.now() - start) / 1000)
-  });
-  res.end();
+  sourceStatus[sourceKey] = 'running';
+  try {
+    const count = await scrape.run(progress => send(progress), source, sourceKey);
+    sourceStatus[sourceKey] = 'ok';
+    send({
+      done: true,
+      added: count,
+      duration: Math.round((Date.now() - start) / 1000)
+    });
+  } catch (err) {
+    sourceStatus[sourceKey] = 'error';
+    logger.error('Manual SSE scrape failed for %s: %s', sourceKey, err.message);
+    send({
+      done: true,
+      error: err.message,
+      duration: Math.round((Date.now() - start) / 1000)
+    });
+  } finally {
+    res.end();
+  }
 });
 
 // SSE streaming variant of the awards scraper.
@@ -1196,13 +1241,26 @@ app.get('/scrape-awarded-stream', requireAuth, async (req, res) => {
 
   const send = data => res.write(`data: ${JSON.stringify(data)}\n\n`);
 
-  const count = await scrapeAwarded.run(progress => send(progress), source, sourceKey);
-  send({
-    done: true,
-    added: count,
-    duration: Math.round((Date.now() - start) / 1000)
-  });
-  res.end();
+  sourceStatus[sourceKey] = 'running';
+  try {
+    const count = await scrapeAwarded.run(progress => send(progress), source, sourceKey);
+    sourceStatus[sourceKey] = 'ok';
+    send({
+      done: true,
+      added: count,
+      duration: Math.round((Date.now() - start) / 1000)
+    });
+  } catch (err) {
+    sourceStatus[sourceKey] = 'error';
+    logger.error('Manual SSE award scrape failed for %s: %s', sourceKey, err.message);
+    send({
+      done: true,
+      error: err.message,
+      duration: Math.round((Date.now() - start) / 1000)
+    });
+  } finally {
+    res.end();
+  }
 });
 
 // Stream log entries to the dashboard so progress can be monitored live. The
@@ -1393,6 +1451,18 @@ app.get('/admin/db-info', requireAuth, requireAdmin, async (req, res) => {
   } catch (err) {
     logger.error('Failed to fetch database info:', err);
     res.status(500).json({ error: 'Failed to fetch data' });
+  }
+});
+
+// Provide the latest per-source scraping statistics so the admin console can
+// refresh timestamps after manual runs without reloading the full page.
+app.get('/admin/source-stats', requireAuth, requireAdmin, async (req, res) => {
+  try {
+    const rows = await db.getSourceStats();
+    res.json(rows);
+  } catch (err) {
+    logger.error('Failed to fetch source stats:', err);
+    res.status(500).json({ error: 'Failed to fetch source statistics' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add individual "Scrape now" controls to the dashboard with live SSE feedback and refreshed styling
- add per-source scrape buttons to the admin console and refresh statistics after manual runs
- expose `/admin/source-stats` and tighten status tracking for manual scrape routes to reflect running/ok/error states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de54f4c13083289509ff524b6996b8