### PR TITLE
Fix tender detail bookmark context escaping

### DIFF
--- a/frontend/tender-detail.ejs
+++ b/frontend/tender-detail.ejs
@@ -77,13 +77,15 @@
     <% } %>
   </section>
   <script>
+    // Protect the embedded JSON from prematurely closing this script block
+    // when tender data includes HTML fragments that resemble closing script tags.
     window.__TENDER_CONTEXT__ = <%- JSON.stringify({
       tender,
       bookmark: bookmark || null,
       detailPayload: detailPayload || null,
       user: user || null,
       bookmarkError: bookmarkError || null
-    }) %>;
+    }).replace(/</g, '\\u003c') %>;
   </script>
   <script src="/tender-detail.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- escape the tender detail context payload so HTML fragments cannot terminate the script block
- document the safeguard to clarify why the escape is required

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de62e1fb2883289f04b25c3fb353b7