### PR TITLE
Add automatic parser inference for new sources

### DIFF
--- a/server/htmlParser.js
+++ b/server/htmlParser.js
@@ -10,12 +10,16 @@
  *   - parseUkri
  *   - parseEuSupply
  *   - parseRss
+ *   - detectParserFromContentType / detectParserFromMarkup
+ *   - inferParserForSource (auto-detect helper)
  *   - parseTenders (exported dispatcher)
  *
  * The parsers rely on Cheerio selectors rather than regex for reliability.
  * Each function returns an array of tender objects with common fields.
  */
 const cheerio = require('cheerio');
+const { fetchText } = require('./httpClient');
+const logger = require('./logger');
 
 /**
  * Identifier used when no parser is specified. Exposed so the UI can present
@@ -75,6 +79,8 @@ const PARSER_CATALOGUE = Object.freeze(
     }
   ].map(option => Object.freeze(option))
 );
+
+const PARSER_KEY_SET = new Set(PARSER_CATALOGUE.map(option => option.key));
 
 /**
  * Normalise a snippet of markup by stripping tags and collapsing whitespace.
@@ -484,6 +490,167 @@ function parseRss(xml) {
 }
 
 /**
+ * Attempt to identify a parser from the server provided content-type header.
+ * Only coarse-grained checks are performed because upstreams are often lax
+ * with their MIME declarations.
+ *
+ * @param {string} contentType Raw content-type header value
+ * @returns {string|null} Parser key if one can be inferred
+ */
+function detectParserFromContentType(contentType = '') {
+  if (!contentType) {
+    return null;
+  }
+
+  const lower = String(contentType).toLowerCase();
+
+  if (lower.includes('rss') || lower.includes('atom')) {
+    return 'rss';
+  }
+
+  if (lower.includes('xml') && (lower.includes('application/') || lower.includes('text/'))) {
+    // Many feeds advertise themselves as generic XML. When this is the case we
+    // still prefer the RSS parser over the HTML fallbacks.
+    return 'rss';
+  }
+
+  return null;
+}
+
+/**
+ * Inspect the downloaded markup to guess which specialised parser best fits
+ * the structure. The heuristics prefer very distinctive markers to reduce the
+ * chance of selecting the wrong parser which would lead to empty scrape
+ * results.
+ *
+ * @param {string} body HTML/XML document body
+ * @returns {string|null} Parser key when a confident match is found
+ */
+function detectParserFromMarkup(body) {
+  if (typeof body !== 'string') {
+    return null;
+  }
+
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // Quick RSS/Atom detection based purely on the raw text to avoid unnecessary
+  // DOM parsing when an XML feed is obvious.
+  if (/<rss\b/i.test(trimmed) || /<feed\b/i.test(trimmed) || /<channel\b/i.test(trimmed)) {
+    return 'rss';
+  }
+
+  let $;
+  try {
+    $ = cheerio.load(trimmed);
+  } catch (error) {
+    logger.error('Failed to parse markup during parser inference: %s', error.message);
+    return null;
+  }
+
+  if ($('rss, channel, feed, item').length > 0) {
+    return 'rss';
+  }
+
+  // EU Supply tables contain distinctive headers and often a dedicated class.
+  const euSpecificTable = $('table.eu-supply-table, table[data-eusupply-table], table#tendersTable');
+  if (euSpecificTable.length > 0) {
+    return 'eusupply';
+  }
+
+  const euHeaders = ['tender title', 'tender reference', 'publication date'];
+  const euHeaderMatches = $('th')
+    .toArray()
+    .map(el => $(el).text().trim().toLowerCase())
+    .filter(text => text && euHeaders.some(marker => text.includes(marker)));
+  if (euHeaderMatches.length >= 2 && $('td.description').length > 0) {
+    return 'eusupply';
+  }
+
+  // Sell2Wales pages typically expose branded captions or table level markers.
+  const sellTables = $('table.sell2wales, table[data-sell2wales-table], table#sell2wales-list');
+  if (sellTables.length > 0) {
+    return 'sell2wales';
+  }
+
+  const sellCaptions = $('caption')
+    .toArray()
+    .map(el => $(el).text().trim().toLowerCase());
+  if (sellCaptions.some(text => text.includes('sell2wales') || text.includes('sell 2 wales'))) {
+    return 'sell2wales';
+  }
+
+  if ($('td.description').length > 0 && /sell2wales/i.test(trimmed)) {
+    return 'sell2wales';
+  }
+
+  // UKRI listings are wrapped in <article> elements with time and anchor tags.
+  const ukriArticles = $('article');
+  if (
+    ukriArticles.length > 0 &&
+    ukriArticles.find('a').length > 0 &&
+    ukriArticles.find('time').length > 0
+  ) {
+    return 'ukri';
+  }
+
+  // Contracts Finder pages contain search-result blocks.
+  if ($('.search-result, .search-result-entry').length > 0) {
+    return DEFAULT_PARSER_KEY;
+  }
+
+  return null;
+}
+
+/**
+ * Fetch a sample document for a source and infer which parser should be used.
+ * The helper is defensive: failures to fetch or classify fall back to the
+ * default parser to avoid breaking source creation flows.
+ *
+ * @param {{url: string, headers?: object}} source Source configuration snippet
+ * @returns {Promise<string>} Parser key present in PARSER_CATALOGUE
+ */
+async function inferParserForSource(source) {
+  if (!source || !source.url) {
+    throw new Error('A source URL is required to infer a parser.');
+  }
+
+  try {
+    const response = await fetchText(source.url, {
+      headers: source.headers,
+      includeMeta: true
+    });
+
+    const body = typeof response === 'string' ? response : response.body;
+    const contentType = typeof response === 'object' ? response.contentType : '';
+
+    const parserFromHeader = detectParserFromContentType(contentType);
+    if (parserFromHeader && PARSER_KEY_SET.has(parserFromHeader)) {
+      logger.info('Parser inference from content-type selected "%s" for %s.', parserFromHeader, source.url);
+      return parserFromHeader;
+    }
+
+    const parserFromMarkup = detectParserFromMarkup(body);
+    if (parserFromMarkup && PARSER_KEY_SET.has(parserFromMarkup)) {
+      logger.info('Parser inference from markup selected "%s" for %s.', parserFromMarkup, source.url);
+      return parserFromMarkup;
+    }
+
+    logger.info(
+      'Parser inference defaulted to "%s" for %s because no specialised parser matched.',
+      DEFAULT_PARSER_KEY,
+      source.url
+    );
+  } catch (error) {
+    logger.error('Parser inference failed for %s: %s', source.url, error.message);
+  }
+
+  return DEFAULT_PARSER_KEY;
+}
+
+/**
  * Dispatch parser based on source configuration. When a selectors object is
  * supplied the new generic parser is used; otherwise the legacy named parsers
  * remain available for backwards compatibility and specialised behaviour.
@@ -522,3 +689,4 @@ exports.parseTenders = function parseTenders(html, source = DEFAULT_PARSER_KEY) 
 
 exports.PARSER_CATALOGUE = PARSER_CATALOGUE;
 exports.DEFAULT_PARSER_KEY = DEFAULT_PARSER_KEY;
+exports.inferParserForSource = inferParserForSource;

--- a/server/httpClient.js
+++ b/server/httpClient.js
@@ -85,13 +85,23 @@ client.interceptors.response.use(
  * @returns {Promise<string>} response body
  */
 async function fetchText(url, options = {}) {
+  const { includeMeta = false, ...axiosOptions } = options;
+
   // `transformResponse` is disabled to avoid implicit JSON parsing when the
   // upstream incorrectly reports a JSON content-type for HTML pages.
   const response = await client.get(url, {
-    ...options,
+    ...axiosOptions,
     responseType: 'text',
     transformResponse: data => data
   });
+
+  if (includeMeta) {
+    return {
+      body: response.data,
+      contentType: response.headers ? response.headers['content-type'] || '' : ''
+    };
+  }
+
   return response.data;
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,8 @@ const fetch = require('node-fetch');
 const {
   parseTenders,
   PARSER_CATALOGUE,
-  DEFAULT_PARSER_KEY
+  DEFAULT_PARSER_KEY,
+  inferParserForSource
 } = require('./htmlParser');
 // Built-in modules used for checking port availability and launching the browser
 const net = require('net');
@@ -1203,8 +1204,7 @@ app.get('/manage-users', requireAuth, (req, res) => {
 // Persist new sources in the database so they remain available after a restart.
 // The parser field defaults to "contractsFinder" since it matches our test HTML.
 app.post('/sources', requireAuth, async (req, res) => {
-  const { key, label, url, base, parser = DEFAULT_PARSER_KEY } = req.body || {};
-  const parserKey = normaliseParserKey(parser);
+  const { key, label, url, base, parser } = req.body || {};
 
   // Basic validation of the supplied data
   if (!key || !label || !url || !base) {
@@ -1225,6 +1225,12 @@ app.post('/sources', requireAuth, async (req, res) => {
   if (config.sources[key]) {
     return res.status(400).json({ error: 'Source key already exists' });
   }
+
+  const hasExplicitParser = typeof parser === 'string' && parser.trim().length > 0;
+  const inferredParserKey = hasExplicitParser
+    ? parser
+    : await inferParserForSource({ url });
+  const parserKey = normaliseParserKey(inferredParserKey);
 
   try {
     // Store the new source definition then add it to the in-memory object used
@@ -1248,8 +1254,7 @@ app.post('/sources', requireAuth, async (req, res) => {
 // new one.
 app.put('/sources/:key', requireAuth, async (req, res) => {
   const key = req.params.key;
-  const { label, url, base, parser = DEFAULT_PARSER_KEY } = req.body || {};
-  const parserKey = normaliseParserKey(parser);
+  const { label, url, base, parser } = req.body || {};
 
   if (!config.sources[key]) {
     return res.status(404).json({ error: 'Source not found' });
@@ -1266,6 +1271,12 @@ app.put('/sources/:key', requireAuth, async (req, res) => {
   if (!urlValidation.valid) {
     return res.status(400).json({ error: urlValidation.message });
   }
+
+  const hasExplicitParser = typeof parser === 'string' && parser.trim().length > 0;
+  const inferredParserKey = hasExplicitParser
+    ? parser
+    : await inferParserForSource({ url });
+  const parserKey = normaliseParserKey(inferredParserKey);
 
   try {
     await db.updateSource(key, label, url, base, parserKey);

--- a/test/parser-detection.test.js
+++ b/test/parser-detection.test.js
@@ -1,0 +1,159 @@
+/**
+ * @file parser-detection.test.js
+ * @description Mini readme: verifies the automatic parser inference helper can
+ *   correctly identify which scraping strategy to apply based on sample
+ *   responses. The tests stub the HTTP client to avoid real network requests
+ *   and feed fixture HTML/XML into the detection heuristics.
+ *
+ * Structure:
+ *   1. Utility `loadModule` helper wires proxyquire with stubbed dependencies.
+ *   2. Individual tests cover RSS, EU Supply, Sell2Wales, UKRI and Contracts
+ *      Finder layouts.
+ *   3. Error handling is exercised to confirm a safe fallback to the default
+ *      parser when fetching fails.
+ */
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+proxyquire.noCallThru();
+proxyquire.noPreserveCache();
+
+function loadModule(configureFetch) {
+  const fetchTextStub = sinon.stub();
+  configureFetch(fetchTextStub);
+  const loggerStub = {
+    info: sinon.stub(),
+    error: sinon.stub()
+  };
+
+  const parserModule = proxyquire('../server/htmlParser', {
+    './httpClient': { fetchText: fetchTextStub },
+    './logger': loggerStub
+  });
+
+  return {
+    inferParserForSource: parserModule.inferParserForSource,
+    DEFAULT_PARSER_KEY: parserModule.DEFAULT_PARSER_KEY,
+    fetchTextStub,
+    loggerStub
+  };
+}
+
+describe('inferParserForSource', () => {
+  it('detects RSS feeds using the content-type header', async () => {
+    const sampleRss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss><channel><title>Feed</title><item><title>A</title></item></channel></rss>`;
+    const { inferParserForSource, fetchTextStub } = loadModule(stub => {
+      stub.resolves({
+        body: sampleRss,
+        contentType: 'application/rss+xml; charset=utf-8'
+      });
+    });
+
+    const parserKey = await inferParserForSource({ url: 'https://example.com/rss' });
+    expect(parserKey).to.equal('rss');
+    expect(
+      fetchTextStub.calledOnceWith('https://example.com/rss', sinon.match({ includeMeta: true }))
+    ).to.be.true;
+  });
+
+  it('detects EU Supply markup from distinctive table headers', async () => {
+    const euHtml = `
+      <html>
+        <body>
+          <table class="eu-supply-table">
+            <thead>
+              <tr><th>Tender Title</th><th>Tender Reference</th><th>Publication Date</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="/tender">Example Tender</a></td>
+                <td class="description">Important works</td>
+                <td><time>2024-05-01</time></td>
+              </tr>
+            </tbody>
+          </table>
+        </body>
+      </html>`;
+
+    const { inferParserForSource } = loadModule(stub => {
+      stub.resolves({ body: euHtml, contentType: 'text/html; charset=utf-8' });
+    });
+
+    const parserKey = await inferParserForSource({ url: 'https://eu.example/list' });
+    expect(parserKey).to.equal('eusupply');
+  });
+
+  it('detects Sell2Wales listings using branded captions', async () => {
+    const sellHtml = `
+      <html>
+        <body>
+          <table data-sell2wales-table="true">
+            <caption>Sell2Wales opportunities</caption>
+            <tbody>
+              <tr>
+                <td><a href="/opp">Opportunity</a></td>
+                <td class="description">Details</td>
+              </tr>
+            </tbody>
+          </table>
+        </body>
+      </html>`;
+
+    const { inferParserForSource } = loadModule(stub => {
+      stub.resolves({ body: sellHtml, contentType: 'text/html' });
+    });
+
+    const parserKey = await inferParserForSource({ url: 'https://sell2wales.example/list' });
+    expect(parserKey).to.equal('sell2wales');
+  });
+
+  it('detects UKRI article based listings', async () => {
+    const ukriHtml = `
+      <html>
+        <body>
+          <article class="ukri-opportunity">
+            <h2><a href="/opp">Research Project</a></h2>
+            <time>2024-05-01</time>
+            <p>Summary</p>
+          </article>
+        </body>
+      </html>`;
+
+    const { inferParserForSource } = loadModule(stub => {
+      stub.resolves({ body: ukriHtml, contentType: 'text/html' });
+    });
+
+    const parserKey = await inferParserForSource({ url: 'https://ukri.example/list' });
+    expect(parserKey).to.equal('ukri');
+  });
+
+  it('falls back to Contracts Finder when search-result blocks exist', async () => {
+    const cfHtml = `
+      <div class="search-result">
+        <h2>Contract</h2>
+        <a href="/contract">View</a>
+      </div>`;
+
+    const { inferParserForSource, DEFAULT_PARSER_KEY } = loadModule(stub => {
+      stub.resolves({ body: cfHtml, contentType: 'text/html' });
+    });
+
+    const parserKey = await inferParserForSource({ url: 'https://cf.example/list' });
+    expect(parserKey).to.equal(DEFAULT_PARSER_KEY);
+  });
+
+  it('returns the default parser and logs on fetch failure', async () => {
+    const fetchError = new Error('network unreachable');
+    const { inferParserForSource, DEFAULT_PARSER_KEY, loggerStub, fetchTextStub } = loadModule(
+      stub => {
+        stub.rejects(fetchError);
+      }
+    );
+
+    const parserKey = await inferParserForSource({ url: 'https://broken.example/list' });
+    expect(parserKey).to.equal(DEFAULT_PARSER_KEY);
+    expect(loggerStub.error.called).to.be.true;
+    expect(fetchTextStub.calledOnce).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- add a parser inference helper that fetches sample markup and chooses the best built-in parser
- extend source management endpoints to auto-populate the parser when it is not provided by the client
- cover the new helper with targeted unit tests exercising each supported parser type

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc6b7bec8832890599ed674e99176