### PR TITLE
Add integration test for runtime source onboarding

### DIFF
--- a/test/fixtures/detail-page.html
+++ b/test/fixtures/detail-page.html
@@ -1,0 +1,32 @@
+<!--
+  File: test/fixtures/detail-page.html
+  Mini README: Simplified opportunity detail page consumed by integration tests.
+  Structure:
+    - Semantic headings naming the metadata fields expected by detailParser.
+    - Paragraphs providing mock values, including an eight-digit CPV code to
+      exercise enrichment behaviour.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Integration Test Opportunity</title>
+  </head>
+  <body>
+    <main>
+      <h2>Published date</h2>
+      <p>2024-03-01</p>
+      <h2>Closing date</h2>
+      <p>2024-03-15</p>
+      <h2>Name of buying organisation</h2>
+      <p>Integration Authority</p>
+      <h2>Description</h2>
+      <p>
+        Comprehensive integration tooling and services. The scope references CPV
+        code 12345678 to validate downstream enrichment.
+      </p>
+      <h2>Eligibility</h2>
+      <p>Open to SME suppliers.</p>
+    </main>
+  </body>
+</html>

--- a/test/fixtures/rss-listing.xml
+++ b/test/fixtures/rss-listing.xml
@@ -1,0 +1,23 @@
+<!--
+  File: test/fixtures/rss-listing.xml
+  Mini README: RSS feed fixture representing a single Contracts Finder tender.
+  Structure:
+    - <rss><channel> container describing the feed metadata.
+    - One <item> element containing title, link, publication date, description
+      and OCID for the tender used by integration tests.
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Integration Feed</title>
+    <link>https://www.contractsfinder.service.gov.uk/integration</link>
+    <description>Contracts Finder feed used for automated testing.</description>
+    <item>
+      <title>Integration Test Opportunity</title>
+      <link>https://www.contractsfinder.service.gov.uk/Notice/123456</link>
+      <pubDate>Fri, 01 Mar 2024 12:00:00 GMT</pubDate>
+      <description><![CDATA[Opportunity to supply integration tooling and support.]]></description>
+      <ocid>ocds-1234567890</ocid>
+    </item>
+  </channel>
+</rss>

--- a/test/source-onboarding.test.js
+++ b/test/source-onboarding.test.js
@@ -1,0 +1,200 @@
+/**
+ * File: test/source-onboarding.test.js
+ * Mini README: Full integration test covering runtime source onboarding.
+ *
+ * Structure:
+ *   - Boot the Express app against an in-memory SQLite database.
+ *   - Authenticate via the real login flow to obtain a CSRF token and session.
+ *   - POST /sources to register a custom feed and run the scraper with HTTP
+ *     fetches stubbed by proxyquire to return deterministic fixtures.
+ *   - Assert that tenders linked to the new source are persisted by the DB API.
+ */
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const fetch = require('node-fetch');
+const sinon = require('sinon');
+const bcrypt = require('bcryptjs');
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+
+// Ensure the server uses the ephemeral in-memory database for the duration of
+// this suite and provide a session secret so Express-session initialises.
+process.env.DB_FILE = ':memory:';
+process.env.SESSION_SECRET = 'test-secret';
+
+// Remove cached modules so the proxyquired versions below are instantiated with
+// the in-memory database configuration.
+['../server/index', '../server/scrape', '../server/db', '../server/config'].forEach(
+  modulePath => {
+    try {
+      delete require.cache[require.resolve(modulePath)];
+    } catch (err) {
+      // Module may not have been loaded yet which is fine.
+    }
+  }
+);
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+const listingFixture = fs.readFileSync(path.join(fixturesDir, 'rss-listing.xml'), 'utf8');
+const detailFixture = fs.readFileSync(path.join(fixturesDir, 'detail-page.html'), 'utf8');
+
+// Stubs injected into the scraper via proxyquire. fetchText returns the RSS
+// listing on the first call then detail HTML for subsequent invocations. The
+// concurrency limiter resolves tasks immediately so the scraper runs
+// synchronously inside the test harness.
+const fetchTextStub = sinon.stub();
+const createLimiterStub = sinon.stub();
+
+const scrape = proxyquire('../server/scrape', {
+  './httpClient': { fetchText: fetchTextStub },
+  './concurrency': { createLimiter: createLimiterStub }
+});
+
+const { app } = proxyquire('../server/index', {
+  './scrape': scrape
+});
+
+const db = require('../server/db');
+const config = require('../server/config');
+
+const TEST_SOURCE_KEY = 'integration-rss-source';
+const TEST_SOURCE_LABEL = 'Integration RSS Source';
+const TEST_USER = { username: 'source-onboarder', password: 'S0urcePass!' };
+const sourcesJsonPath = path.join(__dirname, '..', 'sources.json');
+
+let server;
+let baseUrl;
+
+/**
+ * Helper returning the absolute URL for a route on the ephemeral HTTP server.
+ * @param {string} route - path starting with a forward slash.
+ * @returns {string} absolute URL for the active test server.
+ */
+function url(route) {
+  return `${baseUrl}${route}`;
+}
+
+/**
+ * Retrieve a CSRF token and authenticated session cookie by exercising the real
+ * login flow. The token is reused for subsequent POST requests in the test.
+ *
+ * @returns {Promise<{cookie: string, csrfToken: string}>}
+ */
+async function loginAndGetSession() {
+  const loginPage = await fetch(url('/login'));
+  expect(loginPage.status).to.equal(200);
+  const initialCookieHeader = loginPage.headers.get('set-cookie');
+  expect(initialCookieHeader).to.be.a('string');
+  let sessionCookie = initialCookieHeader.split(';')[0];
+  const html = await loginPage.text();
+  const tokenMatch = html.match(/name="_csrf" value="([^"]+)"/);
+  expect(tokenMatch).to.not.be.null;
+  const csrfToken = tokenMatch[1];
+
+  const formBody = new URLSearchParams({
+    username: TEST_USER.username,
+    password: TEST_USER.password,
+    _csrf: csrfToken
+  });
+
+  const loginResponse = await fetch(url('/login'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Cookie: sessionCookie
+    },
+    body: formBody,
+    redirect: 'manual'
+  });
+  expect(loginResponse.status).to.equal(302);
+  const authCookieHeader = loginResponse.headers.get('set-cookie');
+  if (authCookieHeader) {
+    sessionCookie = authCookieHeader.split(';')[0];
+  }
+
+  return { cookie: sessionCookie, csrfToken };
+}
+
+before(async () => {
+  server = http.createServer(app);
+  await new Promise(resolve => server.listen(0, resolve));
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(() => {
+  if (server) {
+    server.close();
+  }
+});
+
+beforeEach(async () => {
+  // Reset stub behaviour before every test execution.
+  fetchTextStub.resetHistory();
+  fetchTextStub.resetBehavior();
+  fetchTextStub.resolves(detailFixture);
+  fetchTextStub.onFirstCall().resolves(listingFixture);
+
+  createLimiterStub.resetHistory();
+  createLimiterStub.resetBehavior();
+  createLimiterStub.resolves(async task => task());
+
+  if (fs.existsSync(sourcesJsonPath)) {
+    fs.unlinkSync(sourcesJsonPath);
+  }
+
+  // Start from a clean schema and provision the test user account.
+  await db.reset();
+  const hash = await bcrypt.hash(TEST_USER.password, 10);
+  await db.createUser(TEST_USER.username, hash);
+
+  delete config.sources[TEST_SOURCE_KEY];
+});
+
+afterEach(async () => {
+  delete config.sources[TEST_SOURCE_KEY];
+  if (fs.existsSync(sourcesJsonPath)) {
+    fs.unlinkSync(sourcesJsonPath);
+  }
+  await db.reset();
+});
+
+describe('Source onboarding workflow', () => {
+  it('registers a source and scrapes tenders into the database', async () => {
+    const { cookie, csrfToken } = await loginAndGetSession();
+
+    const response = await fetch(url('/sources'), {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Cookie: cookie,
+        'CSRF-Token': csrfToken
+      },
+      body: JSON.stringify({
+        key: TEST_SOURCE_KEY,
+        label: TEST_SOURCE_LABEL,
+        url: 'https://www.contractsfinder.service.gov.uk/custom-feed',
+        base: 'https://www.contractsfinder.service.gov.uk',
+        parser: 'rss'
+      })
+    });
+
+    expect(response.status).to.equal(200);
+    const payload = await response.json();
+    expect(payload).to.have.property('success', true);
+    expect(config.sources).to.have.property(TEST_SOURCE_KEY);
+
+    const added = await scrape.run(null, config.sources[TEST_SOURCE_KEY], TEST_SOURCE_KEY);
+    expect(added).to.be.greaterThan(0);
+
+    const tenders = await db.getTenders();
+    expect(tenders.length).to.be.greaterThan(0);
+    const inserted = tenders.find(tender => tender.source === TEST_SOURCE_LABEL);
+    expect(inserted).to.exist;
+    expect(inserted.cpv).to.include('12345678');
+
+    expect(fetchTextStub.callCount).to.be.at.least(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add an end-to-end source onboarding integration test that drives the Express app, stubs external fetches, and verifies tenders are stored
- provide reusable RSS listing and detail page fixtures consumed by the onboarding test

## Testing
- npm test -- --timeout 10000

------
https://chatgpt.com/codex/tasks/task_e_68e386af4acc832894104954c8ef45bf